### PR TITLE
Rebase datetime64 time coordinates to the first timestamp

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 __all__ = ["Field", "Dataset"]
 
 
-def _coerce_time_to_seconds(t: Array) -> tuple[Array, float]:
+def _coerce_time_to_seconds(t: Array) -> tuple[Array, Array]:
     """Convert a datetime64 time coordinate to relative seconds; pass-through otherwise.
 
     Both ``Dataset.from_arrays`` and ``Dataset.from_xarray`` route through this
@@ -30,7 +30,7 @@ def _coerce_time_to_seconds(t: Array) -> tuple[Array, float]:
     values (~1.7e9 s) are unrepresentable in float32 beyond a 128 s
     granularity, which would silently quantize interpolation weights.
 
-    Plain numeric arrays are returned unchanged with ``t_origin = 0.0`` and are
+    Plain numeric arrays are returned unchanged with ``t_origin = 0`` and are
     treated as "seconds since some user-chosen reference" (the user owns the
     frame; pick a reference near the data, not the Unix epoch, when running in
     float32).
@@ -42,24 +42,27 @@ def _coerce_time_to_seconds(t: Array) -> tuple[Array, float]:
 
     Returns:
         ``(t_seconds, t_origin)`` where ``t_seconds`` is the (possibly rebased)
-        time coordinate array and ``t_origin`` is the epoch offset in seconds
-        (``0.0`` unless the input was ``datetime64``).
+        time coordinate array and ``t_origin`` is the epoch offset as a 0-d
+        NumPy ``int64`` array (``0`` unless the input was ``datetime64``).
+        Integer seconds are exact in int64, and the value is a pytree *leaf*
+        on :class:`Grid` — not static metadata — so datasets differing only
+        in ``t_origin`` do not retrigger jit compilation.
     """
+    import numpy as np
+
     if isinstance(t, jax.Array):
-        return t, 0.0
+        return t, np.array(0, dtype=np.int64)
 
     # The ``Array`` annotation aliases ``jax.Array``, so type checkers flag the
     # lines below as unreachable. They are not: at runtime ``t`` is often a
     # NumPy ``datetime64`` / numeric array (e.g. from ``from_xarray``), which is
     # exactly what this NumPy path handles.
-    import numpy as np
-
     t_arr = np.asarray(t)
     if t_arr.dtype.kind == "M":
         secs = t_arr.astype("datetime64[s]").astype(np.int64)
         origin = int(secs[0]) if secs.size else 0
-        return secs - origin, float(origin)
-    return t_arr, 0.0
+        return secs - origin, np.array(origin, dtype=np.int64)
+    return t_arr, np.array(0, dtype=np.int64)
 
 
 def _nearest_idx(coords: Float[Array, "n"], x: Float[Array, ""], n: int) -> Array:
@@ -443,7 +446,9 @@ class Dataset(eqx.Module):
                 (seconds since an arbitrary reference) or a NumPy ``datetime64``
                 array (any unit); the latter is auto-converted to seconds
                 **relative to the first timestamp**, with the first timestamp
-                stored as ``Grid.t_origin`` (seconds since the Unix epoch).
+                stored as ``Grid.t_origin`` (a 0-d int64 array of seconds
+                since the Unix epoch — a pytree leaf, so changing forcing
+                origins does not retrigger jit compilation).
                 Rebasing keeps float32 time coordinates precise — raw
                 epoch-scale seconds (~1.7e9) have a 128 s float32 granularity.
                 Numeric input is used as-is: choose a reference near the data

--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -19,22 +19,34 @@ if TYPE_CHECKING:
 __all__ = ["Field", "Dataset"]
 
 
-def _coerce_time_to_seconds(t: Array) -> Array:
-    """Convert a datetime64 time coordinate to int seconds; pass-through otherwise.
+def _coerce_time_to_seconds(t: Array) -> tuple[Array, float]:
+    """Convert a datetime64 time coordinate to relative seconds; pass-through otherwise.
 
     Both ``Dataset.from_arrays`` and ``Dataset.from_xarray`` route through this
     helper, so users may pass NumPy ``datetime64`` arrays (any unit) directly:
-    they are reinterpreted as seconds since the Unix epoch. Plain numeric arrays
-    are returned unchanged and are treated as "seconds since some reference"
-    (only differences matter to the solver).
+    they are converted to **seconds since the first timestamp** and the first
+    timestamp itself (as seconds since the Unix epoch) is returned separately
+    as ``t_origin``. Rebasing keeps the stored coordinates small — epoch-scale
+    values (~1.7e9 s) are unrepresentable in float32 beyond a 128 s
+    granularity, which would silently quantize interpolation weights.
+
+    Plain numeric arrays are returned unchanged with ``t_origin = 0.0`` and are
+    treated as "seconds since some user-chosen reference" (the user owns the
+    frame; pick a reference near the data, not the Unix epoch, when running in
+    float32).
 
     JAX arrays (concrete or traced) are passed straight through: JAX has no
     ``datetime64`` dtype, so there is nothing to coerce, and this keeps the
     helper safe to call under ``jax.vmap`` / ``jax.jit`` when ``t`` is a tracer
     (``np.asarray`` on a tracer would raise).
+
+    Returns:
+        ``(t_seconds, t_origin)`` where ``t_seconds`` is the (possibly rebased)
+        time coordinate array and ``t_origin`` is the epoch offset in seconds
+        (``0.0`` unless the input was ``datetime64``).
     """
     if isinstance(t, jax.Array):
-        return t
+        return t, 0.0
 
     # The ``Array`` annotation aliases ``jax.Array``, so type checkers flag the
     # lines below as unreachable. They are not: at runtime ``t`` is often a
@@ -44,8 +56,10 @@ def _coerce_time_to_seconds(t: Array) -> Array:
 
     t_arr = np.asarray(t)
     if t_arr.dtype.kind == "M":
-        return t_arr.astype("datetime64[s]").astype(np.int64)
-    return t_arr
+        secs = t_arr.astype("datetime64[s]").astype(np.int64)
+        origin = int(secs[0]) if secs.size else 0
+        return secs - origin, float(origin)
+    return t_arr, 0.0
 
 
 def _nearest_idx(coords: Float[Array, "n"], x: Float[Array, ""], n: int) -> Array:
@@ -427,8 +441,13 @@ class Dataset(eqx.Module):
             fields: Mapping {field_name: array of shape (time, lat, lon)}.
             t: 1-D time coordinate array. Either equally-spaced numeric values
                 (seconds since an arbitrary reference) or a NumPy ``datetime64``
-                array (any unit); the latter is auto-converted to int seconds
-                since the Unix epoch.
+                array (any unit); the latter is auto-converted to seconds
+                **relative to the first timestamp**, with the first timestamp
+                stored as ``Grid.t_origin`` (seconds since the Unix epoch).
+                Rebasing keeps float32 time coordinates precise — raw
+                epoch-scale seconds (~1.7e9) have a 128 s float32 granularity.
+                Numeric input is used as-is: choose a reference near the data
+                rather than the Unix epoch when running in float32.
             lat: 1-D latitude coordinate array (degrees), equally spaced.
             lon: 1-D longitude coordinate array (degrees), equally spaced.
             dtype: JAX dtype for all arrays (default float32).
@@ -447,7 +466,7 @@ class Dataset(eqx.Module):
         Returns:
             Dataset with all fields on the given grid.
         """
-        t = _coerce_time_to_seconds(t)
+        t, t_origin = _coerce_time_to_seconds(t)
         t_arr   = jnp.asarray(t,   dtype=dtype)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
@@ -462,6 +481,7 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="A",
             lon_period=lon_period,
+            t_origin=t_origin,
         )
         masks = masks or {}
         unknown = set(masks) - set(fields)
@@ -519,6 +539,9 @@ class Dataset(eqx.Module):
 
         Returns:
             Dataset with all fields loaded into host memory as JAX arrays.
+            ``datetime64`` time coordinates are rebased to seconds since the
+            first timestamp (kept as ``Grid.t_origin``); solver times must use
+            the same rebased frame (see :meth:`from_arrays`).
         """
         field_arrays = {
             internal: ds[xr_name].values for internal, xr_name in fields.items()
@@ -565,6 +588,9 @@ class Dataset(eqx.Module):
 
         Args:
             t: 1-D time coordinates (seconds or NumPy ``datetime64``).
+                ``datetime64`` input is rebased to seconds since the first
+                timestamp, stored as ``Grid.t_origin`` (see
+                :meth:`from_arrays`).
             center_lat: 1-D centre latitudes (degrees), equally spaced.
             center_lon: 1-D centre longitudes (degrees), equally spaced.
             vectors: Mapping ``{group_name: {"u": (field_name, u_array),
@@ -621,7 +647,7 @@ class Dataset(eqx.Module):
                 "an empty 'vectors' mapping."
             )
 
-        t = _coerce_time_to_seconds(t)
+        t, t_origin = _coerce_time_to_seconds(t)
         t_arr   = jnp.asarray(t,           dtype=dtype)
         lat_arr = jnp.asarray(center_lat,  dtype=dtype)
         lon_arr = jnp.asarray(center_lon,  dtype=dtype)
@@ -638,6 +664,7 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="C",
             lon_period=lon_period,
+            t_origin=t_origin,
         )
         derived_u_lat, derived_u_lon = centre_grid.u_face_coords()
         derived_v_lat, derived_v_lon = centre_grid.v_face_coords()
@@ -660,6 +687,7 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="C",
             lon_period=lon_period,
+            t_origin=t_origin,
             u_lat_coords=u_lat_arr,
             u_lon_coords=u_lon_arr,
             v_lat_coords=v_lat_arr,

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -46,6 +46,13 @@ class Grid(eqx.Module):
         lon_period: If set (e.g. ``360.0``), longitude is treated as periodic
             with that period. The centre grid is assumed to span exactly one
             period.
+        t_origin: Epoch offset of the time axis, in seconds since the Unix
+            epoch. ``t_coords`` are relative to this instant, i.e. the absolute
+            time of ``t_coords[i]`` is ``t_origin + t_coords[i]``. Loaders set
+            it when converting ``datetime64`` input (which is rebased to the
+            first timestamp so the stored float32 coordinates stay small and
+            precise); it is ``0.0`` for plain numeric time input. Solver times
+            (``t0`` and interpolation queries) live in the same rebased frame.
         u_lat_coords, u_lon_coords: U-face coordinates (NEMO C-grid). Populated
             by the C-grid loaders (derived from the centre grid via
             :meth:`u_face_coords` or supplied explicitly); ``None`` on A-grids.
@@ -62,6 +69,7 @@ class Grid(eqx.Module):
     )
     stagger_type: Literal["A", "C"] = eqx.field(static=True, default="A")
     lon_period: float | None = eqx.field(static=True, default=None)
+    t_origin: float = eqx.field(static=True, default=0.0)
     u_lat_coords: Float[Array, "..."] | None = None
     u_lon_coords: Float[Array, "..."] | None = None
     v_lat_coords: Float[Array, "..."] | None = None

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -22,8 +22,9 @@ from typing import Literal
 
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 
-from ._types import Array, Float
+from ._types import Array, Float, Int
 
 __all__ = ["Grid"]
 
@@ -47,12 +48,20 @@ class Grid(eqx.Module):
             with that period. The centre grid is assumed to span exactly one
             period.
         t_origin: Epoch offset of the time axis, in seconds since the Unix
-            epoch. ``t_coords`` are relative to this instant, i.e. the absolute
-            time of ``t_coords[i]`` is ``t_origin + t_coords[i]``. Loaders set
-            it when converting ``datetime64`` input (which is rebased to the
-            first timestamp so the stored float32 coordinates stay small and
-            precise); it is ``0.0`` for plain numeric time input. Solver times
-            (``t0`` and interpolation queries) live in the same rebased frame.
+            epoch, stored as a 0-d ``int64`` array. ``t_coords`` are relative
+            to this instant, i.e. the absolute time of ``t_coords[i]`` is
+            ``t_origin + t_coords[i]``. Loaders set it when converting
+            ``datetime64`` input (which is rebased to the first timestamp so
+            the stored float32 coordinates stay small and precise); it is
+            ``0`` for plain numeric time input. Solver times (``t0`` and
+            interpolation queries) live in the same rebased frame.
+
+            ``t_origin`` is a pytree *leaf*, not static metadata: swapping
+            forcing datasets with different origins does not retrigger jit
+            compilation. Integer seconds are exact in int64; read the value
+            host-side with ``int(grid.t_origin)``. Inside ``jax.jit`` (without
+            ``jax_enable_x64``) the leaf is canonicalized to int32, which
+            remains exact for epoch seconds until 2038.
         u_lat_coords, u_lon_coords: U-face coordinates (NEMO C-grid). Populated
             by the C-grid loaders (derived from the centre grid via
             :meth:`u_face_coords` or supplied explicitly); ``None`` on A-grids.
@@ -69,7 +78,9 @@ class Grid(eqx.Module):
     )
     stagger_type: Literal["A", "C"] = eqx.field(static=True, default="A")
     lon_period: float | None = eqx.field(static=True, default=None)
-    t_origin: float = eqx.field(static=True, default=0.0)
+    t_origin: Int[Array, ""] = eqx.field(
+        default_factory=lambda: np.array(0, dtype=np.int64)
+    )
     u_lat_coords: Float[Array, "..."] | None = None
     u_lon_coords: Float[Array, "..."] | None = None
     v_lat_coords: Float[Array, "..."] | None = None

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -176,8 +176,9 @@ class TestDataset:
             coordinates={"time": "time", "lat": "lat", "lon": "lon"},
         )
         field = dataset["u"]
-        t_s = float(np.datetime64("2020-01-01T12:00:00", "s").astype(np.int64))
-        v = field.interp(jnp.array(t_s, dtype=jnp.float32), jnp.array(11.0), jnp.array(1.0))
+        # datetime64 time is rebased to seconds since the first timestamp:
+        # 2020-01-01T12:00:00 is 43200 s after the first stamp.
+        v = field.interp(jnp.array(43200.0), jnp.array(11.0), jnp.array(1.0))
         assert float(v) == pytest.approx(1.0, abs=1e-5)
 
     def test_getitem(self):
@@ -198,7 +199,7 @@ class TestDataset:
         )
         # Use a large-enough grid: ds has 3 points per axis, window=1 → need 3 points → OK
         patches = dataset.neighborhood(
-            jnp.array(float(np.datetime64("2020-01-02", "s").astype(np.int64)), dtype=jnp.float32),
+            jnp.array(86400.0),  # 2020-01-02, rebased to the first timestamp
             jnp.array(11.0),
             jnp.array(1.0),
         )
@@ -249,17 +250,54 @@ class TestDatasetFromArrays:
         assert float(v) == pytest.approx(1.5)
 
     def test_from_arrays_accepts_datetime64(self):
-        """Passing a numpy datetime64 time array to from_arrays auto-converts to seconds."""
+        """datetime64 time is rebased to seconds since the first timestamp."""
         t_dt = np.array(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"],
                         dtype="datetime64[D]")
         _, lat, lon = self._coords()
         u = np.ones((4, 4, 4), dtype=np.float32)
         dataset = Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
-        expected = t_dt.astype("datetime64[s]").astype(np.int64)
+        epoch = t_dt.astype("datetime64[s]").astype(np.int64)
+        expected = epoch - epoch[0]
         assert jnp.allclose(
             dataset["u"].t_coords,
             jnp.asarray(expected, dtype=dataset["u"].t_coords.dtype),
         )
+        assert dataset.grid.t_origin == float(epoch[0])
+
+    def test_datetime64_rebasing_preserves_float32_precision(self):
+        """Hourly datetime64 coords at a 2026 epoch stay exact in float32.
+
+        Raw epoch seconds (~1.77e9) have a 128 s float32 granularity, so
+        without rebasing hourly steps cannot be represented and interpolation
+        weights are quantized. After rebasing, coords are small integers and
+        a mid-cell time query interpolates exactly.
+        """
+        t_dt = np.arange(
+            np.datetime64("2026-07-01T00:00:00"),
+            np.datetime64("2026-07-01T04:00:00"),
+            np.timedelta64(1, "h"),
+        )
+        lat = np.linspace(0.0, 3.0, 4)
+        lon = np.linspace(10.0, 13.0, 4)
+        # Field value equals the hour index at every grid point.
+        u = np.broadcast_to(
+            np.arange(4, dtype=np.float32)[:, None, None], (4, 4, 4)
+        )
+        dataset = Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
+        assert jnp.array_equal(
+            dataset["u"].t_coords, jnp.array([0.0, 3600.0, 7200.0, 10800.0])
+        )
+        # Mid-cell query: exactly half-way between hours 1 and 2.
+        v = dataset["u"].interp(jnp.array(5400.0), jnp.array(11.0), jnp.array(1.0))
+        assert float(v) == pytest.approx(1.5, abs=1e-6)
+
+    def test_numeric_time_passes_through_unrebased(self):
+        """Plain numeric time input keeps its frame and t_origin stays 0."""
+        t, lat, lon = self._coords()
+        u = np.ones((4, 4, 4), dtype=np.float32)
+        dataset = Dataset.from_arrays({"u": u}, t=t + 123.0, lat=lat, lon=lon)
+        assert dataset.grid.t_origin == 0.0
+        assert float(dataset["u"].t_coords[0]) == pytest.approx(123.0)
 
     def test_from_arrays_datetime64_matches_from_xarray(self):
         """from_arrays with datetime64 and from_xarray must yield identical t_coords."""
@@ -495,6 +533,11 @@ class TestDatasetCGrid:
         assert jnp.allclose(from_xr["v"].values, from_arr["v"].values)
         assert jnp.allclose(from_xr["u"].lon_coords, from_arr["u"].lon_coords)
         assert jnp.allclose(from_xr["v"].lat_coords, from_arr["v"].lat_coords)
+        # datetime64 time is rebased identically on both paths.
+        epoch0 = float(t.astype("datetime64[s]").astype(np.int64)[0])
+        assert from_xr.grid.t_origin == epoch0
+        assert from_arr.grid.t_origin == epoch0
+        assert float(from_xr.grid.t_coords[0]) == 0.0
 
     def test_from_xarray_cgrid_with_explicit_staggered_coords(self):
         t = np.linspace(0.0, 7200.0, 3)

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -262,7 +262,8 @@ class TestDatasetFromArrays:
             dataset["u"].t_coords,
             jnp.asarray(expected, dtype=dataset["u"].t_coords.dtype),
         )
-        assert dataset.grid.t_origin == float(epoch[0])
+        assert int(dataset.grid.t_origin) == int(epoch[0])
+        assert dataset.grid.t_origin.dtype == np.int64
 
     def test_datetime64_rebasing_preserves_float32_precision(self):
         """Hourly datetime64 coords at a 2026 epoch stay exact in float32.
@@ -291,12 +292,38 @@ class TestDatasetFromArrays:
         v = dataset["u"].interp(jnp.array(5400.0), jnp.array(11.0), jnp.array(1.0))
         assert float(v) == pytest.approx(1.5, abs=1e-6)
 
+    def test_different_t_origin_does_not_retrace_jit(self):
+        """t_origin is a pytree leaf: swapping forcing origins must not recompile."""
+
+        def build(day):
+            t_dt = np.arange(
+                np.datetime64(day),
+                np.datetime64(day) + np.timedelta64(4, "h"),
+                np.timedelta64(1, "h"),
+            )
+            lat = np.linspace(0.0, 3.0, 4)
+            lon = np.linspace(10.0, 13.0, 4)
+            u = np.ones((4, 4, 4), dtype=np.float32)
+            return Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
+
+        traces = {"n": 0}
+
+        @jax.jit
+        def f(ds):
+            traces["n"] += 1  # runs at trace time only
+            return ds["u"].interp(jnp.array(1800.0), jnp.array(11.0), jnp.array(1.0))
+
+        v1 = f(build("2026-07-01T00:00"))
+        v2 = f(build("2026-09-01T00:00"))  # same shapes, different t_origin
+        assert traces["n"] == 1
+        assert float(v1) == pytest.approx(float(v2))
+
     def test_numeric_time_passes_through_unrebased(self):
         """Plain numeric time input keeps its frame and t_origin stays 0."""
         t, lat, lon = self._coords()
         u = np.ones((4, 4, 4), dtype=np.float32)
         dataset = Dataset.from_arrays({"u": u}, t=t + 123.0, lat=lat, lon=lon)
-        assert dataset.grid.t_origin == 0.0
+        assert int(dataset.grid.t_origin) == 0
         assert float(dataset["u"].t_coords[0]) == pytest.approx(123.0)
 
     def test_from_arrays_datetime64_matches_from_xarray(self):
@@ -534,9 +561,9 @@ class TestDatasetCGrid:
         assert jnp.allclose(from_xr["u"].lon_coords, from_arr["u"].lon_coords)
         assert jnp.allclose(from_xr["v"].lat_coords, from_arr["v"].lat_coords)
         # datetime64 time is rebased identically on both paths.
-        epoch0 = float(t.astype("datetime64[s]").astype(np.int64)[0])
-        assert from_xr.grid.t_origin == epoch0
-        assert from_arr.grid.t_origin == epoch0
+        epoch0 = int(t.astype("datetime64[s]").astype(np.int64)[0])
+        assert int(from_xr.grid.t_origin) == epoch0
+        assert int(from_arr.grid.t_origin) == epoch0
         assert float(from_xr.grid.t_coords[0]) == 0.0
 
     def test_from_xarray_cgrid_with_explicit_staggered_coords(self):

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -318,6 +318,64 @@ class TestDatasetFromArrays:
         assert traces["n"] == 1
         assert float(v1) == pytest.approx(float(v2))
 
+    def test_t_origin_traces_through_solve_without_recompiling(self):
+        """t_origin flows into the solver term as a traced value, not a constant.
+
+        The absolute epoch time ``t + grid.t_origin`` (the month-of-year use
+        case) is recovered inside the term and drives a seasonal signal. A
+        single jitted program must:
+
+        * trace exactly once across datasets with different ``t_origin`` and a
+          changed ``t0`` (no recompilation), and
+        * still produce *different* trajectories for different origins —
+          proving ``t_origin`` is a runtime input threaded all the way into
+          the term, not baked into the trace as a constant.
+        """
+        from pastax import Euler
+
+        def build(day):
+            t_dt = np.arange(
+                np.datetime64(day),
+                np.datetime64(day) + np.timedelta64(6, "h"),
+                np.timedelta64(1, "h"),
+            )
+            lat = np.linspace(0.0, 3.0, 4)
+            lon = np.linspace(10.0, 13.0, 4)
+            u = np.ones((6, 4, 4), dtype=np.float32)
+            v = np.zeros((6, 4, 4), dtype=np.float32)
+            return Dataset.from_arrays({"u": u, "v": v}, t=t_dt, lat=lat, lon=lon)
+
+        year = 365.25 * 86400.0
+
+        def term(t, y, args):
+            ds = args
+            abs_t = t + ds.grid.t_origin  # absolute epoch seconds (traced leaf)
+            season = jnp.sin(2.0 * jnp.pi * abs_t / year)
+            u = ds["u"].interp(t, y[0], y[1])
+            v = ds["v"].interp(t, y[0], y[1])
+            return jnp.array([u, v]) + 1e-3 * season
+
+        traces = {"n": 0}
+
+        @jax.jit
+        def run(ds, t0):
+            traces["n"] += 1  # trace-time only
+            return solve(
+                term, jnp.array([11.0, 1.0]), t0,
+                n_save=3, int_dt=3600.0, save_dt=3600.0,
+                solver=Euler(), args=ds,
+            )
+
+        r_jul = run(build("2026-07-01T00:00"), jnp.array(0.0))
+        r_sep = run(build("2026-09-01T00:00"), jnp.array(0.0))  # different origin
+        _ = run(build("2026-07-01T00:00"), jnp.array(3600.0))   # different t0
+
+        assert traces["n"] == 1  # no recompilation
+        assert jnp.all(jnp.isfinite(r_jul)) and jnp.all(jnp.isfinite(r_sep))
+        # Different origins → different seasonal phase → different trajectory,
+        # so t_origin genuinely reached the term as a runtime value.
+        assert not jnp.allclose(r_jul, r_sep)
+
     def test_numeric_time_passes_through_unrebased(self):
         """Plain numeric time input keeps its frame and t_origin stays 0."""
         t, lat, lon = self._coords()


### PR DESCRIPTION
## Problem

`_coerce_time_to_seconds` converts `datetime64` input to raw seconds since the Unix epoch (~1.75e9 s today), and the loaders cast to the default `float32`, whose spacing at that magnitude is **128 seconds**. Every time coordinate gets quantized to a 128 s grid, so hourly-forcing interpolation weights are off by up to ~3.5 % and sub-hourly forcing is unusable.

## Fix

- `datetime64` time is converted to seconds **relative to the first timestamp**, keeping stored float32 coordinates small and exact.
- The epoch offset is stored on the new `Grid.t_origin` attribute as a **0-d NumPy int64 array leaf** (a regular pytree leaf, *not* static metadata). Absolute times are recovered as `t_origin + t_coords[i]`; solver times (`t0`, interpolation queries) live in the rebased frame.

This avoids relying on `jax_enable_x64` (an x64 time axis would be silently truncated back to float32 inside `jit` anyway) and keeps everything traceable:

- **No recompilation.** `t_origin` is a dynamic leaf, so datasets differing only in their origin flatten to the same tracer signature — swapping forcing datasets does not retrigger compilation.
- **Traced all the way.** Passed through `solve(..., args=dataset)` under `jit`, `t_origin` arrives inside the term as a tracer, so `t + args.grid.t_origin` (the month-of-year / seasonal-forcing use case) works and stays exact — int64 host-side, and still exact after JAX's int32 canonicalization inside `jit` (epoch seconds fit int32 until 2038). int64 beats float64 here because a float64 leaf is canonicalized to float32 inside `jit`, reintroducing the 128 s quantization this PR removes.

Plain numeric time input is unchanged (`t_origin == 0`) — the user owns the frame.

## Tests

- Hourly `datetime64` coords at a 2026 epoch produce exact `[0, 3600, 7200, 10800]` float32 coords and an exact mid-cell interpolation (previously quantized to 128 s).
- Two datasets identical except for `t_origin` hit a single `jax.jit` trace through `interp`.
- **End-to-end:** a jitted `solve` whose term recovers `t + grid.t_origin` to drive a seasonal signal traces exactly once across different origins and a changed `t0` (no recompilation) yet yields different trajectories per origin — proving `t_origin` reaches the term as a traced runtime input, not a baked-in constant.
- Numeric time passes through unrebased; C-grid loaders rebase identically; existing datetime64 tests updated to the rebased frame.