### PR TITLE
Use int_dt directly as the integration step size

### DIFF
--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -706,14 +706,13 @@ def _run_ode(
     term: Callable,
     y0: Float[Array, "2"],
     ts: Float[Array, " time"],
+    dt: float,
     solver: AbstractSolver,
     args: PyTree | None = None,
     controls: PyTree | None = None,
     adjoint: str = "checkpointed",
     checkpoints: int | str | None = None,
 ) -> Float[Array, "time 2"]:
-    dt = ts[1] - ts[0]
-
     if args is None and controls is None:
         def body(y: Float[Array, "2"], t: Float[Array, ""]) -> tuple:
             term_fn = lambda t_, y_, a_, c_: term(t_, y_)
@@ -751,6 +750,7 @@ def _run_sde(
     term: Callable,
     y0: Float[Array, "2"],
     ts: Float[Array, " time"],
+    dt: float,
     solver: AbstractSolver,
     z_seq: Float[Array, "steps 2"],
     args: PyTree | None = None,
@@ -758,8 +758,6 @@ def _run_sde(
     adjoint: str = "checkpointed",
     checkpoints: int | str | None = None,
 ) -> Float[Array, "time 2"]:
-    dt = ts[1] - ts[0]
-
     if args is None and controls is None:
         def body(y: Float[Array, "2"], inputs: Float[Array, ""]) -> tuple:
             t, z = inputs
@@ -907,15 +905,15 @@ def solve(
         noise_proto = y0 if brownian_structure is None else brownian_structure
         if n_samples == 1:
             z = _sample_noise(key, n_fine, noise_proto)
-            result = _run_sde(term, y0, ts_fine, solver, z, args, controls, adjoint, checkpoints)
+            result = _run_sde(term, y0, ts_fine, int_dt, solver, z, args, controls, adjoint, checkpoints)
             return _subsample(result, n_substeps)
         else:
             keys = jr.split(key, n_samples)
             z = jax.vmap(lambda k: _sample_noise(k, n_fine, noise_proto))(keys)
             result = jax.vmap(
-                lambda z_: _run_sde(term, y0, ts_fine, solver, z_, args, controls, adjoint, checkpoints)
+                lambda z_: _run_sde(term, y0, ts_fine, int_dt, solver, z_, args, controls, adjoint, checkpoints)
             )(z)
             return _subsample(result, n_substeps, axis=1)
     else:
-        result = _run_ode(term, y0, ts_fine, solver, args, controls, adjoint, checkpoints)
+        result = _run_ode(term, y0, ts_fine, int_dt, solver, args, controls, adjoint, checkpoints)
         return _subsample(result, n_substeps)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -805,3 +805,37 @@ class TestLineaxDiffusion:
                      key=jax.random.key(4), brownian_structure=noise_proto)
         assert traj.shape == (11, 2)
         assert jnp.all(jnp.isfinite(traj))
+
+
+class TestExactStepSize:
+    """The integration step must be int_dt exactly, not ts[1] - ts[0]."""
+
+    def test_large_t0_does_not_quantize_dt(self):
+        # At t0 ~ 1.75e9 (epoch-scale seconds) float32 spacing is 128 s, so a
+        # step recovered as ts[1] - ts[0] would be a multiple of 128 (e.g.
+        # 3584) instead of 3600. With a constant velocity the endpoint is
+        # exactly y0 + v * n * int_dt when the exact step is used.
+        v = jnp.array([1e-5, -2e-5])
+
+        def term(t, y):
+            return v
+
+        y0 = jnp.array([-4.0, 48.0])
+        t0 = jnp.array(1.75e9)
+        n_save, dt = 4, 3600.0
+        traj = solve(term, y0, t0, n_save, dt, dt, Euler())
+        expected = y0 + v * n_save * dt
+        assert jnp.allclose(traj[-1], expected, rtol=1e-6, atol=0.0)
+
+    def test_large_t0_sde_drift_uses_exact_dt(self):
+        drift = jnp.array([1e-5, 0.0])
+
+        def term(t, y):
+            return drift, jnp.zeros(2)  # zero diffusion: deterministic drift
+
+        y0 = jnp.zeros(2)
+        t0 = jnp.array(1.75e9)
+        n_save, dt = 4, 3600.0
+        traj = solve(term, y0, t0, n_save, dt, dt, Euler(), key=jax.random.key(0))
+        expected = y0 + drift * n_save * dt
+        assert jnp.allclose(traj[-1], expected, rtol=1e-6, atol=0.0)


### PR DESCRIPTION
## Problem

`_run_ode` and `_run_sde` recovered the step size as `ts[1] - ts[0]`. With an epoch-scale `t0` (~1.7e9 s), the float32 fine time grid is quantized to 128 s spacing, so the recovered step can be e.g. 3584 s instead of 3600 s — silently biasing every integration step (~0.4 % velocity error for hourly steps).

## Fix

`solve` already knows `int_dt` exactly (it's a static Python float); pass it down to `_run_ode` / `_run_sde` instead of recomputing it from the time array.

## Tests

Two regression tests (ODE and SDE drift) integrate a constant-velocity term from `t0 = 1.75e9` and assert the endpoint equals `y0 + v * n * int_dt` to `rtol=1e-6`. Both fail on `main` and pass with this change. Full suite: 280 passed.

Complements #6 (which fixes the same quantization at the forcing level. 