### PR TITLE
Reject n_save < 1 in solve

### DIFF
--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -843,8 +843,8 @@ def solve(
             ``(2,)``) is the single-leaf case. Defines the output structure.
         t0: Start time in seconds. JAX scalar — can change between calls without
             recompilation. The implicit end time is ``t0 + n_save * save_dt``.
-        n_save: Number of output intervals (static). Each output leaf has a leading
-            ``n_save + 1`` axis including the initial state.
+        n_save: Number of output intervals (static, ``>= 1``). Each output leaf
+            has a leading ``n_save + 1`` axis including the initial state.
         int_dt: Integration step size in seconds (static). Use a negative value
             for backward-in-time integration.
         save_dt: Output interval in seconds (static). Must be an integer multiple
@@ -889,6 +889,9 @@ def solve(
 
     if adjoint not in ("checkpointed", "forward"):
         raise ValueError(f'adjoint must be "checkpointed" or "forward", got {adjoint!r}.')
+
+    if n_save < 1:
+        raise ValueError(f"n_save must be >= 1, got {n_save}.")
 
     n_substeps = round(save_dt / int_dt)
     if n_substeps < 1:

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -805,3 +805,19 @@ class TestLineaxDiffusion:
                      key=jax.random.key(4), brownian_structure=noise_proto)
         assert traj.shape == (11, 2)
         assert jnp.all(jnp.isfinite(traj))
+
+
+class TestNSaveValidation:
+    def test_n_save_zero_raises(self):
+        def term(t, y):
+            return jnp.zeros(2)
+
+        with pytest.raises(ValueError, match="n_save must be >= 1"):
+            solve(term, jnp.zeros(2), jnp.array(0.0), 0, 1.0, 1.0)
+
+    def test_n_save_negative_raises(self):
+        def term(t, y):
+            return jnp.zeros(2)
+
+        with pytest.raises(ValueError, match="n_save must be >= 1"):
+            solve(term, jnp.zeros(2), jnp.array(0.0), -3, 1.0, 1.0)


### PR DESCRIPTION
## Problem

`solve(term, y0, t0, n_save=0, ...)` builds a one-element fine time grid; JAX's clamped out-of-bounds indexing then turns `ts[1] - ts[0]` into `0` instead of raising, so the call silently "integrates" with `dt = 0`.

## Fix

Validate `n_save >= 1` up front and raise a `ValueError` with a clear message. Docstring updated.

## Tests

`n_save=0` and `n_save=-3` both raise.