### PR TITLE
Validate field shapes in Dataset.from_arrays

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -439,6 +439,7 @@ class Dataset(eqx.Module):
         t_arr   = jnp.asarray(t,   dtype=dtype)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
+        nt   = int(t_arr.shape[0])
         nlat = int(lat_arr.shape[0])
         nlon = int(lon_arr.shape[0])
         grid = Grid(
@@ -453,6 +454,13 @@ class Dataset(eqx.Module):
         loaded: dict[str, Field] = {}
         for name, v in fields.items():
             v_arr = jnp.asarray(v, dtype=dtype)
+            if v_arr.shape != (nt, nlat, nlon):
+                raise ValueError(
+                    f"fields[{name!r}]: expected shape (time, lat, lon) = "
+                    f"{(nt, nlat, nlon)} matching the coordinate arrays, got "
+                    f"{v_arr.shape}. Check the axis order — data stored as "
+                    "(time, lon, lat) must be transposed."
+                )
             clean, mask = _resolve_mask(
                 v_arr, masks.get(name),
                 expected_mask_shape=(nlat, nlon),

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -600,3 +600,35 @@ class TestDatasetCGrid:
         lon_final = float(traj[-1, 0])
         assert lat_final == pytest.approx(2.0 * float(np.exp(beta  * T)), rel=1e-3)
         assert lon_final == pytest.approx(2.0 * float(np.exp(alpha * T)), rel=1e-3)
+
+
+class TestFromArraysShapeValidation:
+    def _coords(self):
+        t   = np.linspace(0.0, 3 * 3600.0, 4)
+        lat = np.linspace(0.0, 2.0, 3)
+        lon = np.linspace(10.0, 14.0, 5)
+        return t, lat, lon
+
+    def test_matching_shape_passes(self):
+        t, lat, lon = self._coords()
+        u = np.ones((4, 3, 5), dtype=np.float32)
+        dataset = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+        assert dataset["u"].values.shape == (4, 3, 5)
+
+    def test_transposed_lat_lon_raises(self):
+        t, lat, lon = self._coords()
+        u = np.ones((4, 5, 3), dtype=np.float32)  # (time, lon, lat) by mistake
+        with pytest.raises(ValueError, match=r"fields\['u'\].*expected shape"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+
+    def test_wrong_time_length_raises(self):
+        t, lat, lon = self._coords()
+        u = np.ones((3, 3, 5), dtype=np.float32)
+        with pytest.raises(ValueError, match="expected shape"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+
+    def test_2d_field_raises(self):
+        t, lat, lon = self._coords()
+        u = np.ones((3, 5), dtype=np.float32)
+        with pytest.raises(ValueError, match="expected shape"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)


### PR DESCRIPTION
## Problem

`Dataset.from_arrays_cgrid` shape-checks every array against the NEMO convention, but the A-grid `Dataset.from_arrays` accepted any array. A `(time, lon, lat)`-transposed field — an easy mistake — silently produced garbage interpolation instead of an error.

## Fix

Each field array must match `(nt, nlat, nlon)` as implied by the coordinate arrays; otherwise a `ValueError` names the field, the expected shape, and hints at the transposition mistake.

## Tests

Matching shape passes; transposed lat/lon, wrong time length, and 2-D input all raise.