### PR TITLE
Evaluate the diffusion Jacobian once per Milstein step

### DIFF
--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -528,28 +528,25 @@ class EulerHeun(AbstractSolver):
         return _add(y, _scale(dt, f0), _scale(0.5, _add(diff0, diff1)))
 
 
-def _milstein_correction(
+def _diffusion_jac_diag(
     term: Callable,
     t: Float[Array, ""],
     y: Float[Array, "2"],
     args: PyTree,
     ctrl: PyTree,
-    g: Float[Array, "2"],
-    dW: Float[Array, "n_noise"],
 ) -> Float[Array, "2"]:
-    r"""Diagonal-noise Milstein cross-term :math:`\tfrac12\,g\,(\partial g_i/\partial y_i)\,dW^2`.
+    r"""Diagonal :math:`\partial g_i/\partial y_i` of a diagonal diffusion coefficient.
 
-    Returns the :math:`\tfrac12\,g\,(\partial g_i/\partial y_i)\,dW^2` vector
-    (Stratonovich form). Itô subtracts
-    :math:`\tfrac12\,g\,(\partial g_i/\partial y_i)\,dt` on top.
+    Computed once per step via ``jax.jacfwd`` and shared between the Milstein
+    cross-term :math:`\tfrac12\,g\,(\partial g_i/\partial y_i)\,dW^2` and the
+    Itô drift correction :math:`-\tfrac12\,g\,(\partial g_i/\partial y_i)\,dt`.
     """
     def g_fn(y_):
         _, g_out = term(t, y_, args, ctrl)
         return g_out
 
     dgdy = jax.jacfwd(g_fn)(y)            # (2, 2)
-    dgdy_diag = jnp.diag(dgdy)
-    return 0.5 * g * dgdy_diag * dW ** 2
+    return jnp.diag(dgdy)
 
 
 class ItoMilstein(AbstractSolver):
@@ -596,13 +593,8 @@ class ItoMilstein(AbstractSolver):
                 f"got g.shape == {g.shape}. Use EulerHeun for matrix diffusion."
             )
         dW = jnp.sqrt(jnp.abs(dt)) * z
-        cross = _milstein_correction(term, t, y, args, ctrl, g, dW)
-        def g_fn(y_):
-            _, g_out = term(t, y_, args, ctrl)
-            return g_out
-        dgdy_diag = jnp.diag(jax.jacfwd(g_fn)(y))
-        ito_drift = -0.5 * g * dgdy_diag * dt
-        return y + f * dt + g * dW + cross + ito_drift
+        dgdy_diag = _diffusion_jac_diag(term, t, y, args, ctrl)
+        return y + f * dt + g * dW + 0.5 * g * dgdy_diag * (dW ** 2 - dt)
 
 
 class StratonovichMilstein(AbstractSolver):
@@ -650,8 +642,8 @@ class StratonovichMilstein(AbstractSolver):
                 f"got g.shape == {g.shape}. Use EulerHeun for matrix diffusion."
             )
         dW = jnp.sqrt(jnp.abs(dt)) * z
-        cross = _milstein_correction(term, t, y, args, ctrl, g, dW)
-        return y + f * dt + g * dW + cross
+        dgdy_diag = _diffusion_jac_diag(term, t, y, args, ctrl)
+        return y + f * dt + g * dW + 0.5 * g * dgdy_diag * dW ** 2
 
 
 def _sample_noise(

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -805,3 +805,41 @@ class TestLineaxDiffusion:
                      key=jax.random.key(4), brownian_structure=noise_proto)
         assert traj.shape == (11, 2)
         assert jnp.all(jnp.isfinite(traj))
+
+
+class TestMilsteinSingleJacobian:
+    """The diffusion Jacobian must be evaluated once per Milstein step."""
+
+    def _count_term_calls(self, solver_cls):
+        calls = {"n": 0}
+
+        def term(t, y, args, ctrl):
+            calls["n"] += 1
+            return jnp.zeros(2), 0.1 * y  # linear diagonal diffusion
+
+        y = jnp.array([1.0, 2.0])
+        solver_cls().sde_step(term, jnp.array(0.0), y, 0.5, None, None, jnp.ones(2))
+        return calls["n"]
+
+    def test_ito_milstein_two_term_evaluations(self):
+        # One evaluation for (f, g) plus one traced through jacfwd.
+        assert self._count_term_calls(ItoMilstein) == 2
+
+    def test_stratonovich_milstein_two_term_evaluations(self):
+        assert self._count_term_calls(StratonovichMilstein) == 2
+
+    def test_ito_milstein_step_matches_closed_form(self):
+        # g(y) = a * y (diagonal) -> dg_i/dy_i = a, so the Ito Milstein update is
+        # y + f dt + g dW + 0.5 * g * a * (dW^2 - dt).
+        a, dt = 0.3, 0.5
+        f = jnp.array([0.01, -0.02])
+        y = jnp.array([1.0, 2.0])
+        z = jnp.array([0.7, -1.1])
+
+        def term(t, y_, args, ctrl):
+            return f, a * y_
+
+        dW = jnp.sqrt(dt) * z
+        expected = y + f * dt + a * y * dW + 0.5 * (a * y) * a * (dW ** 2 - dt)
+        got = ItoMilstein().sde_step(term, jnp.array(0.0), y, dt, None, None, z)
+        assert jnp.allclose(got, expected, rtol=1e-6)


### PR DESCRIPTION
## Problem

`ItoMilstein.sde_step` computed `jax.jacfwd` of the diffusion coefficient twice per step — once inside `_milstein_correction` for the cross-term and once again for the Itô drift correction — doubling the most expensive part of the step.

## Fix

Replace `_milstein_correction` with `_diffusion_jac_diag`, which returns the Jacobian diagonal once; both the cross-term and the Itô drift correction reuse it. The update is numerically identical (`0.5 g g' dW² − 0.5 g g' dt` becomes `0.5 g g' (dW² − dt)`); `StratonovichMilstein` shares the helper.

## Tests

- Term-evaluation counters assert both Milstein solvers now trace the term exactly twice per step (once for `(f, g)`, once through `jacfwd`) — previously three times.
- A closed-form check for linear diagonal diffusion `g(y) = a·y` pins the Itô update formula.