### PR TITLE
Require ascending longitudes when lon_period is set

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -439,6 +439,7 @@ class Dataset(eqx.Module):
         t_arr   = jnp.asarray(t,   dtype=dtype)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
+        _check_periodic_lon_ascending(lon_arr, lon_period)
         nlat = int(lat_arr.shape[0])
         nlon = int(lon_arr.shape[0])
         grid = Grid(
@@ -594,6 +595,7 @@ class Dataset(eqx.Module):
         t_arr   = jnp.asarray(t,           dtype=dtype)
         lat_arr = jnp.asarray(center_lat,  dtype=dtype)
         lon_arr = jnp.asarray(center_lon,  dtype=dtype)
+        _check_periodic_lon_ascending(lon_arr, lon_period)
 
         nt   = int(t_arr.shape[0])
         nlat = int(lat_arr.shape[0])
@@ -779,6 +781,26 @@ class Dataset(eqx.Module):
             dtype=dtype,
             lon_period=lon_period,
             masks=masks,
+        )
+
+
+def _check_periodic_lon_ascending(
+    lon_arr: Float[Array, "lon"], lon_period: float | None
+) -> None:
+    """Reject descending longitudes when periodic wrapping is requested.
+
+    The periodic index arithmetic folds queries with ``% lon_period`` above
+    ``lon_coords[0]``, which assumes an ascending axis; a descending axis
+    silently produces wrong indices and weights. (Without ``lon_period``,
+    descending coordinates work — the spacing sign cancels.)
+    """
+    if lon_period is None:
+        return
+    if not bool(jnp.all(jnp.diff(lon_arr) > 0)):
+        raise ValueError(
+            "lon_period requires strictly ascending longitude coordinates; "
+            "the periodic wrap arithmetic is undefined on a descending axis. "
+            "Flip the longitude axis (and the field values) before loading."
         )
 
 

--- a/src/pastax/interpolation.py
+++ b/src/pastax/interpolation.py
@@ -42,6 +42,12 @@ def _periodic_index_and_weight(
     ``coords[n] == coords[0] + period``, with ``coords[n]`` not stored. The
     returned index ``i`` is in ``[0, n-1]``; the right neighbour is
     ``(i + 1) % n``.
+
+    ``coords`` must be **ascending** (``dx > 0``): the ``% period`` fold maps
+    the query into ``[0, period)`` above ``coords[0]``, which is inconsistent
+    with a negative ``dx``. (The non-periodic :func:`_index_and_weight`
+    handles descending coordinates fine — the sign cancels in ``(x - x0)/dx``.)
+    The loaders enforce this when ``lon_period`` is set.
     """
     x0 = coords[0]
     dx = coords[1] - coords[0]
@@ -94,8 +100,10 @@ def bilinear_interp_2d(
             as periodic with that period; the grid is assumed to span exactly
             one period (``n_lon * dlon == lon_period``) and the cell at
             ``lon_coords[-1] + dlon`` is identified with ``lon_coords[0]``.
-            ``None`` (default) reproduces the non-wrapping behaviour with
-            linear extrapolation past the boundary.
+            Periodic longitudes must be **ascending** (see
+            :func:`_periodic_index_and_weight`). ``None`` (default) reproduces
+            the non-wrapping behaviour with linear extrapolation past the
+            boundary.
         mask: Optional 2-D boolean land mask, same shape as ``values``.
             ``True`` marks a land cell. Behaviour by mixed-corner count:
 

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -600,3 +600,38 @@ class TestDatasetCGrid:
         lon_final = float(traj[-1, 0])
         assert lat_final == pytest.approx(2.0 * float(np.exp(beta  * T)), rel=1e-3)
         assert lon_final == pytest.approx(2.0 * float(np.exp(alpha * T)), rel=1e-3)
+
+
+class TestPeriodicLonAscending:
+    """lon_period demands ascending longitudes; descending ones must raise."""
+
+    def test_descending_lon_with_period_raises(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.array([0.0, 1.0])
+        lon = np.array([270.0, 180.0, 90.0, 0.0])  # descending
+        u = np.ones((2, 2, 4), dtype=np.float32)
+        with pytest.raises(ValueError, match="strictly ascending longitude"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon, lon_period=360.0)
+
+    def test_descending_lon_without_period_still_works(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.array([0.0, 1.0])
+        lon = np.array([13.0, 12.0, 11.0, 10.0])  # descending, non-periodic
+        u = np.broadcast_to(np.array([3.0, 2.0, 1.0, 0.0], dtype=np.float32), (2, 2, 4))
+        ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+        # values encode lon - 10, so interp at lon=11.5 must give 1.5
+        v = ds["u"].interp(jnp.array(0.0), jnp.array(11.5), jnp.array(0.5))
+        assert float(v) == pytest.approx(1.5, abs=1e-6)
+
+    def test_cgrid_descending_lon_with_period_raises(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.linspace(0.0, 4.0, 5)
+        lon = np.array([300.0, 240.0, 180.0, 120.0, 60.0, 0.0])  # descending
+        u = np.ones((2, 5, 5), dtype=np.float32)
+        v = np.ones((2, 4, 6), dtype=np.float32)
+        with pytest.raises(ValueError, match="strictly ascending longitude"):
+            Dataset.from_arrays_cgrid(
+                t, lat, lon,
+                vectors={"current": {"u": ("uo", u), "v": ("vo", v)}},
+                lon_period=360.0,
+            )


### PR DESCRIPTION
## Problem

`_periodic_index_and_weight` folds queries with `% lon_period` above `lon_coords[0]`, which assumes an ascending axis. On a descending longitude axis it silently produces wrong indices and weights — asymmetric with the non-periodic path, where descending coordinates work fine because the spacing sign cancels in `(x - x0) / dx`.

## Fix

The loaders (`from_arrays`, `from_arrays_cgrid`, and therefore the xarray variants) reject `lon_period` combined with non-ascending longitudes, with a message telling the user to flip the axis. The ascending requirement is documented on `_periodic_index_and_weight` and `bilinear_interp_2d`.

## Tests

Descending + periodic raises on both loaders; descending + non-periodic still interpolates correctly (regression-pinned).