### PR TITLE
Warn when the inferred NaN mask is not time-invariant

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -807,7 +807,12 @@ def _resolve_mask(
        ``expected_mask_shape`` and used as-is. Time-varying (3-D) masks are
        rejected.
     3. Otherwise, if NaN was present in ``values``, infer a 2-D mask from
-       ``isnan(values).any(axis=0)``.
+       ``isnan(values).any(axis=0)``. Cells that are NaN at *some but not
+       all* time steps are almost certainly missing data (sensor gaps)
+       rather than land — land is time-invariant. Such cells still end up
+       masked (and zero-filled), but a ``UserWarning`` is emitted so the
+       gap does not silently become a permanent wall; pass an explicit
+       mask to silence it.
     4. If no user mask and no NaN, return ``mask=None`` — the resulting
        Field is bit-exact identical (PyTree structure included) to one
        built before the mask feature was added.
@@ -831,6 +836,20 @@ def _resolve_mask(
 
     if bool(nan_locs.any()):
         inferred = nan_locs.any(axis=0)
+        transient = inferred & ~nan_locs.all(axis=0)
+        if bool(transient.any()):
+            import warnings
+
+            warnings.warn(
+                f"Field {field_name!r}: {int(transient.sum())} cell(s) are NaN "
+                "at some but not all time steps. Land is time-invariant, so "
+                "these look like missing data (sensor gaps), yet they will be "
+                "masked as land for the whole simulation (values zero-filled). "
+                "Fill the gaps or pass an explicit mask to silence this "
+                "warning.",
+                UserWarning,
+                stacklevel=2,
+            )
         return clean_values, inferred
 
     return clean_values, None

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -61,8 +61,9 @@ class TestFromArraysMask:
         t, lat, lon = self._coords()
         u = np.ones((3, 4, 5), dtype=np.float32)
         u[:, 0, 0] = np.nan       # one land cell
-        u[1, 2, 3] = np.nan       # NaN at one timestep only — still land
-        ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+        u[1, 2, 3] = np.nan       # NaN at one timestep only — masked, with a warning
+        with pytest.warns(UserWarning, match="some but not all time steps"):
+            ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
 
         assert ds["u"].mask is not None
         assert ds["u"].mask.shape == (4, 5)
@@ -557,3 +558,49 @@ class TestClosedBay:
         assert float(traj[-1, 1]) == pytest.approx(2.0, abs=1e-5)
         # And no NaN anywhere.
         assert bool(jnp.all(jnp.isfinite(traj))) is True
+
+
+class TestTransientNaNWarning:
+    """NaN at some-but-not-all time steps looks like missing data, not land."""
+
+    def _coords(self):
+        t = np.linspace(0.0, 3600.0, 3)
+        lat = np.linspace(0.0, 2.0, 3)
+        lon = np.linspace(10.0, 13.0, 4)
+        return t, lat, lon
+
+    def test_transient_nan_warns(self):
+        t, lat, lon = self._coords()
+        u = np.ones((3, 3, 4), dtype=np.float32)
+        u[1, 0, 0] = np.nan  # NaN at one time step only: a gap, not land
+        with pytest.warns(UserWarning, match="some but not all time steps"):
+            ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+        # The cell is still masked (conservative) and zero-filled.
+        assert bool(ds["u"].mask[0, 0]) is True
+        assert not bool(jnp.isnan(ds["u"].values).any())
+
+    def test_time_invariant_nan_does_not_warn(self):
+        import warnings as _warnings
+
+        t, lat, lon = self._coords()
+        u = np.ones((3, 3, 4), dtype=np.float32)
+        u[:, 0, 0] = np.nan  # land: NaN at every time step
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon)
+        assert bool(ds["u"].mask[0, 0]) is True
+
+    def test_explicit_mask_silences_warning(self):
+        import warnings as _warnings
+
+        t, lat, lon = self._coords()
+        u = np.ones((3, 3, 4), dtype=np.float32)
+        u[1, 0, 0] = np.nan
+        mask = np.zeros((3, 4), dtype=bool)
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            ds = Dataset.from_arrays(
+                {"u": u}, t=t, lat=lat, lon=lon, masks={"u": mask}
+            )
+        assert ds["u"].mask is not None
+        assert not bool(ds["u"].mask.any())


### PR DESCRIPTION
## Problem

The inferred land mask is `isnan(values).any(axis=0)`, so a single missing time step (a sensor gap, not land) permanently masks that cell as land and zero-fills it for the whole simulation — silently.

## Fix

Land is time-invariant. Cells that are NaN at *some but not all* time steps now trigger a `UserWarning` naming the field and the number of affected cells, advising to fill the gaps or pass an explicit mask. The masking behaviour itself is unchanged (still conservative: any-NaN → masked).

## Tests

Transient NaN warns; all-time NaN (true land) does not; an explicit mask silences the warning. The one existing test that mixes both cases now asserts the warning. Full suite: 281 passed (also clean under `-W error::UserWarning`).