### PR TITLE
Reject degenerate ensembles in energy_score and dawid_sebastiani

### DIFF
--- a/src/pastax/score.py
+++ b/src/pastax/score.py
@@ -137,6 +137,12 @@ def dawid_sebastiani(
         Per-time score of shape ``(T,)`` or a scalar, per ``reduce``.
     """
 
+    if forecast.shape[0] < 3:
+        raise ValueError(
+            "dawid_sebastiani requires an ensemble of size S >= 3 (the ddof=1 "
+            f"sample covariance is singular below that); got S = {forecast.shape[0]}."
+        )
+
     def _one_t(fcst_t: Float[Array, "S 2"], obs_t: Float[Array, "2"]) -> Float[Array, ""]:
         s = fcst_t.shape[0]
         mu = fcst_t.mean(axis=0)
@@ -184,6 +190,11 @@ def energy_score(
         Per-time score of shape ``(T,)`` or a scalar, per ``reduce``.
     """
     s = forecast.shape[0]
+    if s < 2:
+        raise ValueError(
+            "energy_score requires an ensemble of size S >= 2 (the unbiased "
+            f"pairwise term divides by S - 1); got S = {s}."
+        )
 
     bias_per_t = jnp.mean(kernel(forecast, obs) ** alpha, axis=0)
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -363,3 +363,24 @@ def test_reduce_invalid_value_raises():
     o = jnp.zeros((2, 2))
     with pytest.raises(ValueError, match="reduce"):
         squared_error(f, o, reduce="mean")  # type: ignore[arg-type]
+
+
+class TestEnsembleSizeValidation:
+    """Degenerate ensembles must raise instead of returning inf/NaN."""
+
+    def test_energy_score_single_member_raises(self):
+        forecast = jnp.zeros((1, 5, 2))
+        obs = jnp.zeros((5, 2))
+        with pytest.raises(ValueError, match="S >= 2"):
+            energy_score(forecast, obs)
+
+    def test_energy_score_two_members_ok(self):
+        forecast = jnp.stack([jnp.zeros((5, 2)), jnp.ones((5, 2))])
+        obs = jnp.zeros((5, 2))
+        assert jnp.all(jnp.isfinite(energy_score(forecast, obs)))
+
+    def test_dawid_sebastiani_two_members_raises(self):
+        forecast = jnp.zeros((2, 5, 2))
+        obs = jnp.zeros((5, 2))
+        with pytest.raises(ValueError, match="S >= 3"):
+            dawid_sebastiani(forecast, obs)


### PR DESCRIPTION
## Problem

- `energy_score` with a single ensemble member divides by `S - 1 = 0` in the unbiased pairwise term and silently returns inf/NaN.
- `dawid_sebastiani` with `S < 3` has an (a.s.) singular `ddof=1` sample covariance and silently returns NaN.

Both minimums were documented but not enforced, and a NaN score deep in a training loop is painful to trace back.

## Fix

The ensemble size is static (`forecast.shape[0]`), so both functions now raise a `ValueError` stating the minimum and the received size.

## Tests

`S=1` energy score raises; `S=2` energy score is finite; `S=2` Dawid–Sebastiani raises.