### PR TITLE
Validate the controls leading axis in solve

### DIFF
--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -901,6 +901,17 @@ def solve(
             f"save_dt ({save_dt}) must be an integer multiple of int_dt ({int_dt})."
         )
     n_fine = n_save * n_substeps
+
+    if controls is not None:
+        for leaf in jax.tree.leaves(controls):
+            if jnp.ndim(leaf) < 1 or leaf.shape[0] != n_fine:
+                raise ValueError(
+                    "Every controls leaf needs a leading axis of length "
+                    f"n_fine = n_save * round(save_dt / int_dt) = {n_fine}; "
+                    f"got a leaf of shape {jnp.shape(leaf)}. The solver slices "
+                    "controls[i] at each of the n_fine integration steps."
+                )
+
     ts_fine = t0 + jnp.arange(n_fine + 1) * int_dt
 
     if key is not None:

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -805,3 +805,36 @@ class TestLineaxDiffusion:
                      key=jax.random.key(4), brownian_structure=noise_proto)
         assert traj.shape == (11, 2)
         assert jnp.all(jnp.isfinite(traj))
+
+
+class TestControlsLengthValidation:
+    """controls leaves must have a leading axis of exactly n_fine."""
+
+    @staticmethod
+    def _term(t, y, ctrl):
+        return jnp.zeros(2) + ctrl
+
+    def test_wrong_length_raises(self):
+        # n_save rows while sub-stepping needs n_fine = n_save * 2.
+        ctrl = jnp.zeros((5, 2))
+        with pytest.raises(ValueError, match="n_fine = "):
+            solve(self._term, jnp.zeros(2), jnp.array(0.0), 5, 0.5, 1.0,
+                  controls=ctrl)
+
+    def test_scalar_leaf_raises(self):
+        with pytest.raises(ValueError, match="leading axis"):
+            solve(self._term, jnp.zeros(2), jnp.array(0.0), 5, 1.0, 1.0,
+                  controls=jnp.array(1.0))
+
+    def test_correct_length_passes(self):
+        ctrl = jnp.zeros((10, 2))
+        traj = solve(self._term, jnp.zeros(2), jnp.array(0.0), 5, 0.5, 1.0,
+                     controls=ctrl)
+        assert traj.shape == (6, 2)
+
+    def test_pytree_controls_validated_per_leaf(self):
+        good = jnp.zeros((10, 2))
+        bad = jnp.zeros((6, 2))
+        with pytest.raises(ValueError, match="n_fine = "):
+            solve(lambda t, y, c: jnp.zeros(2), jnp.zeros(2), jnp.array(0.0),
+                  5, 0.5, 1.0, controls={"a": good, "b": bad})


### PR DESCRIPTION
## Problem

A `controls` PyTree whose leading axis is not `n_fine` — e.g. `n_save` rows while sub-stepping (`int_dt < save_dt`) — failed deep inside `lax.scan` with an opaque shape-mismatch error that never mentions the controls contract.

## Fix

`solve` validates every `controls` leaf up front: each needs a leading axis of exactly `n_fine = n_save * round(save_dt / int_dt)`. The error message spells out the formula.

## Tests

Wrong length raises; scalar leaf raises; correct length passes; PyTree controls are validated per leaf.