### PR TITLE
Document the all-land zero as a fill value for tracers

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -183,7 +183,9 @@ class Field(eqx.Module):
             instead of extrapolating. When ``self.mask`` is set, coastal
             cells use inverse-distance partial-cell weighting and fully
             land-bound cells return ``0`` (see
-            :func:`pastax.interpolation.bilinear_interp_2d`).
+            :func:`pastax.interpolation.bilinear_interp_2d`) — the right
+            answer for velocities, but an arbitrary fill value for masked
+            tracers (an SST of ``0`` over land is a value, not a gap).
         """
         lat_coords, lon_coords = self.grid.coords_for(self.stagger)
         return spatiotemporal_interp(

--- a/src/pastax/interpolation.py
+++ b/src/pastax/interpolation.py
@@ -109,6 +109,12 @@ def bilinear_interp_2d(
             * All four corners land → returns ``0`` (zero velocity for
               fully-grounded cells).
 
+            The all-land ``0`` is the physically right answer for velocity
+            components (a grounded particle does not move) but is an
+            arbitrary fill for tracers — an SST of ``0`` °C over land is a
+            value, not a gap. When interpolating masked tracers, treat
+            results in all-land cells as fill values, not data.
+
             The :math:`\varepsilon` floor and :func:`safe_divide` keep both
             forward and backward passes finite for queries on or near a corner.
 


### PR DESCRIPTION
Documentation only.

Masked interpolation returns `0` in fully land-bound cells. That is the physically correct answer for velocity components (a grounded particle does not move), but for tracers it is an arbitrary fill — an SST of `0` °C over land is a value, not a gap, and could silently skew anything consuming interpolated tracers near coasts.

`bilinear_interp_2d` and `Field.interp` docstrings now call this out. (A configurable `fill_value` could follow later if tracer use grows.)