### PR TITLE
Document the seam-face limitation of periodic C-grids

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -569,7 +569,11 @@ class Dataset(eqx.Module):
                 as periodic in longitude. Tracer fields receive
                 ``lon_period``; U/V faces do not (their coordinate arrays
                 no longer span a full period, so periodic wrapping would be
-                ill-defined at first order).
+                ill-defined at first order). In particular the seam U face
+                between ``lon[-1]`` and ``lon[0] + lon_period`` is not
+                represented, and U/V fields extrapolate instead of wrapping
+                across the seam — see :meth:`pastax.Grid.period_for` for the
+                implications and workarounds.
             masks: Optional land masks keyed by the field names declared in
                 ``vectors`` and ``tracers``. Each mask is a 2-D bool array;
                 the expected shape per field is ``(nlat, nlon - 1)`` for a

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -150,6 +150,14 @@ class Grid(eqx.Module):
         Centre (tracer) fields inherit :attr:`lon_period`. U/V faces always get
         ``None``: their coordinate arrays no longer span a full period, so
         periodic wrapping would be ill-defined at first order.
+
+        Consequence for global (periodic) C-grids: the U face between
+        ``lon_c[-1]`` and ``lon_c[0] + lon_period`` — the seam face — is not
+        represented (there are ``nlon - 1`` U faces, not ``nlon``), and face
+        fields *extrapolate* rather than wrap across the seam. Queries near
+        the seam meridian therefore lose the C-grid's coastal guarantees; if
+        trajectories cross the seam, prefer A-grid forcing or rotate the grid
+        so the seam sits over land.
         """
         return self.lon_period if stagger == "center" else None
 


### PR DESCRIPTION
Documentation only.

On a global (periodic) C-grid, the U face sitting on the seam — between `lon[-1]` and `lon[0] + lon_period` — is not represented: the loaders derive `nlon - 1` U faces, and U/V face fields always get `lon_period=None`, so they **extrapolate** rather than wrap across the seam. Queries near the seam meridian therefore lose the C-grid's coastal guarantees.

`Grid.period_for` and `from_arrays_cgrid` now spell out the consequence and the workarounds (A-grid forcing, or rotating the grid so the seam sits over land).