### PR TITLE
Make ruff pass and run it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
+      - name: Lint
+        run: ruff check src tests
+
       - name: Run tests
         run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
+# jaxtyping shape annotations (e.g. Float[Array, "time lat lon"]) are string
+# subscripts, not forward references; F722/F821/UP037 all misfire on them.
+# See https://docs.kidger.site/jaxtyping/faq/
+ignore = ["F722", "F821", "UP037"]
 
 [tool.pyright]
 pythonVersion = "3.11"

--- a/src/pastax/__init__.py
+++ b/src/pastax/__init__.py
@@ -2,13 +2,13 @@
 
 from ._safe_math import safe_divide, safe_log, safe_sqrt
 from .forcing import Dataset, Field
-from .grid import Grid
 from .geo import (
     EARTH_RADIUS,
     degrees_to_meters,
     haversine,
     meters_to_degrees,
 )
+from .grid import Grid
 from .interpolation import bilinear_interp_2d, linear_interp_1d, spatiotemporal_interp
 from .metric import liu_index, normalized_separation_distance, separation_distance
 from .score import (

--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -13,7 +13,6 @@ from .grid import Grid
 from .interpolation import spatiotemporal_interp, spatiotemporal_velocity_partialslip
 
 if TYPE_CHECKING:
-    import numpy as np
     import xarray as xr
     from jax import DTypeLike
 

--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -586,7 +586,10 @@ class ItoMilstein(AbstractSolver):
         ctrl: PyTree,
         z: PyTree,
     ) -> PyTree:
-        r"""One Itô Milstein step: :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,(dW^2 - dt)`."""
+        r"""One Itô Milstein step:
+        
+        :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,(dW^2 - dt)`.
+        """
         if not _is_bare_array(y):
             raise NotImplementedError(
                 "ItoMilstein requires a flat array state; PyTree states are not "
@@ -635,7 +638,10 @@ class StratonovichMilstein(AbstractSolver):
         ctrl: PyTree,
         z: PyTree,
     ) -> PyTree:
-        r"""One Stratonovich Milstein step: :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,dW^2`."""
+        r"""One Stratonovich Milstein step:
+        
+        :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,dW^2`.
+        """
         if not _is_bare_array(y):
             raise NotImplementedError(
                 "StratonovichMilstein requires a flat array state; PyTree states are "

--- a/src/pastax/solver.py
+++ b/src/pastax/solver.py
@@ -75,7 +75,7 @@ solver sign-abs-normalises the :math:`\sqrt{dt}` factor.
 from __future__ import annotations
 
 import abc
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import equinox.internal as eqxi  # pyright: ignore[reportMissingImports]  # checkpointed scan
@@ -395,12 +395,15 @@ class Tsit5(AbstractSolver):
         """One Tsit5 step (5th-order weights only)."""
         k1 = term(t, y, args, ctrl)
         k2 = term(t + _TSIT5_C2 * dt, _rk_stage(y, dt, (_TSIT5_A21,), (k1,)), args, ctrl)
-        k3 = term(t + _TSIT5_C3 * dt, _rk_stage(y, dt, (_TSIT5_A31, _TSIT5_A32), (k1, k2)), args, ctrl)
+        k3 = term(t + _TSIT5_C3 * dt,
+                  _rk_stage(y, dt, (_TSIT5_A31, _TSIT5_A32), (k1, k2)),
+                  args, ctrl)
         k4 = term(t + _TSIT5_C4 * dt,
                   _rk_stage(y, dt, (_TSIT5_A41, _TSIT5_A42, _TSIT5_A43), (k1, k2, k3)),
                   args, ctrl)
         k5 = term(t + _TSIT5_C5 * dt,
-                  _rk_stage(y, dt, (_TSIT5_A51, _TSIT5_A52, _TSIT5_A53, _TSIT5_A54), (k1, k2, k3, k4)),
+                  _rk_stage(y, dt, (_TSIT5_A51, _TSIT5_A52, _TSIT5_A53, _TSIT5_A54),
+                            (k1, k2, k3, k4)),
                   args, ctrl)
         k6 = term(t + _TSIT5_C6 * dt,
                   _rk_stage(y, dt, (_TSIT5_A61, _TSIT5_A62, _TSIT5_A63, _TSIT5_A64, _TSIT5_A65),
@@ -583,7 +586,10 @@ class ItoMilstein(AbstractSolver):
         ctrl: PyTree,
         z: Float[Array, "n_noise"],
     ) -> Float[Array, "2"]:
-        r"""One Itô Milstein step: :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,(dW^2 - dt)`."""
+        r"""One Itô Milstein step.
+
+        :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,(dW^2 - dt)`
+        """
         if not _is_bare_array(y):
             raise NotImplementedError(
                 "ItoMilstein requires a flat array state; PyTree states are not "
@@ -637,7 +643,10 @@ class StratonovichMilstein(AbstractSolver):
         ctrl: PyTree,
         z: Float[Array, "n_noise"],
     ) -> Float[Array, "2"]:
-        r"""One Stratonovich Milstein step: :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,dW^2`."""
+        r"""One Stratonovich Milstein step.
+
+        :math:`y + f\,dt + g\,dW + \tfrac12\,g\,(\partial g/\partial y)\,dW^2`
+        """
         if not _is_bare_array(y):
             raise NotImplementedError(
                 "StratonovichMilstein requires a flat array state; PyTree states are "
@@ -716,24 +725,28 @@ def _run_ode(
 
     if args is None and controls is None:
         def body(y: Float[Array, "2"], t: Float[Array, ""]) -> tuple:
-            term_fn = lambda t_, y_, a_, c_: term(t_, y_)
+            def term_fn(t_, y_, a_, c_):
+                return term(t_, y_)
             y_new = solver.ode_step(term_fn, t, y, dt, None, None)
             return y_new, y_new
     elif args is not None and controls is None:
         def body(y: Float[Array, "2"], t: Float[Array, ""]) -> tuple:
-            term_fn = lambda t_, y_, a_, c_: term(t_, y_, a_)
+            def term_fn(t_, y_, a_, c_):
+                return term(t_, y_, a_)
             y_new = solver.ode_step(term_fn, t, y, dt, args, None)
             return y_new, y_new
     elif args is None and controls is not None:
         def body(y: Float[Array, "2"], inputs: tuple) -> tuple:
             t, ctrl = inputs
-            bound = lambda t_, y_, a_, c_: term(t_, y_, c_)
+            def bound(t_, y_, a_, c_):
+                return term(t_, y_, c_)
             y_new = solver.ode_step(bound, t, y, dt, None, ctrl)
             return y_new, y_new
     else:
         def body(y: Float[Array, "2"], inputs: tuple) -> tuple:
             t, ctrl = inputs
-            bound = lambda t_, y_, a_, c_: term(t_, y_, a_, c_)
+            def bound(t_, y_, a_, c_):
+                return term(t_, y_, a_, c_)
             y_new = solver.ode_step(bound, t, y, dt, args, ctrl)
             return y_new, y_new
         
@@ -763,25 +776,29 @@ def _run_sde(
     if args is None and controls is None:
         def body(y: Float[Array, "2"], inputs: Float[Array, ""]) -> tuple:
             t, z = inputs
-            term_fn = lambda t_, y_, a_, c_: term(t_, y_)
+            def term_fn(t_, y_, a_, c_):
+                return term(t_, y_)
             y_new = solver.sde_step(term_fn, t, y, dt, None, None, z)
             return y_new, y_new
     elif args is not None and controls is None:
         def body(y: Float[Array, "2"], inputs: Float[Array, ""]) -> tuple:
             t, z = inputs
-            term_fn = lambda t_, y_, a_, c_: term(t_, y_, a_)
+            def term_fn(t_, y_, a_, c_):
+                return term(t_, y_, a_)
             y_new = solver.sde_step(term_fn, t, y, dt, args, None, z)
             return y_new, y_new
     elif args is None and controls is not None:
         def body(y: Float[Array, "2"], inputs: tuple) -> tuple:
             t, z, ctrl = inputs
-            bound = lambda t_, y_, a_, c_: term(t_, y_, c_)
+            def bound(t_, y_, a_, c_):
+                return term(t_, y_, c_)
             y_new = solver.sde_step(bound, t, y, dt, None, ctrl, z)
             return y_new, y_new
     else:
         def body(y: Float[Array, "2"], inputs: tuple) -> tuple:
             t, z, ctrl = inputs
-            bound = lambda t_, y_, a_, c_: term(t_, y_, a_, c_)
+            def bound(t_, y_, a_, c_):
+                return term(t_, y_, a_, c_)
             y_new = solver.sde_step(bound, t, y, dt, args, ctrl, z)
             return y_new, y_new
         
@@ -907,13 +924,15 @@ def solve(
         noise_proto = y0 if brownian_structure is None else brownian_structure
         if n_samples == 1:
             z = _sample_noise(key, n_fine, noise_proto)
-            result = _run_sde(term, y0, ts_fine, solver, z, args, controls, adjoint, checkpoints)
+            result = _run_sde(term, y0, ts_fine, solver, z, args, controls,
+                              adjoint, checkpoints)
             return _subsample(result, n_substeps)
         else:
             keys = jr.split(key, n_samples)
             z = jax.vmap(lambda k: _sample_noise(k, n_fine, noise_proto))(keys)
             result = jax.vmap(
-                lambda z_: _run_sde(term, y0, ts_fine, solver, z_, args, controls, adjoint, checkpoints)
+                lambda z_: _run_sde(term, y0, ts_fine, solver, z_, args, controls,
+                                    adjoint, checkpoints)
             )(z)
             return _subsample(result, n_substeps, axis=1)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import jax
-import jax.numpy as jnp
-import pytest
 
 # Use CPU and 64-bit floats for test precision
 jax.config.update("jax_platform_name", "cpu")

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -64,12 +64,14 @@ class TestUnitConversions:
     def test_round_trip_at_equator(self):
         disp_m = jnp.array([1000.0, 1000.0])
         lat = jnp.array(0.0)
-        assert jnp.allclose(degrees_to_meters(meters_to_degrees(disp_m, lat), lat), disp_m, rtol=1e-5)
+        assert jnp.allclose(degrees_to_meters(meters_to_degrees(disp_m, lat), lat),
+                            disp_m, rtol=1e-5)
 
     def test_round_trip_at_45deg(self):
         disp_m = jnp.array([5000.0, 5000.0])
         lat = jnp.array(45.0)
-        assert jnp.allclose(degrees_to_meters(meters_to_degrees(disp_m, lat), lat), disp_m, rtol=1e-5)
+        assert jnp.allclose(degrees_to_meters(meters_to_degrees(disp_m, lat), lat),
+                            disp_m, rtol=1e-5)
 
     def test_longitude_scaling_at_60deg(self):
         lat = jnp.array(60.0)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -98,7 +98,8 @@ class TestFromArraysMask:
         t, lat, lon = self._coords()
         u = np.ones((3, 4, 5), dtype=np.float32)
         v = np.ones((3, 4, 5), dtype=np.float32)
-        u_mask = np.zeros((4, 5), dtype=bool); u_mask[0, 0] = True
+        u_mask = np.zeros((4, 5), dtype=bool)
+        u_mask[0, 0] = True
         ds = Dataset.from_arrays(
             {"u": u, "v": v}, t=t, lat=lat, lon=lon, masks={"u": u_mask},
         )
@@ -504,7 +505,8 @@ class TestAlongshoreJetNoStuckParticle:
         from pastax import Heun, solve
         ds = self._dataset(with_mask=False)
         y0 = jnp.array([0.5, 0.1], dtype=jnp.float32)  # [lon, lat], just above coast
-        traj = solve(self._term(), y0, jnp.array(0.0), 10, 0.5, 0.5, solver=Heun(), args=ds)  # 5 seconds
+        traj = solve(self._term(), y0, jnp.array(0.0), 10, 0.5, 0.5,
+                     solver=Heun(), args=ds)  # 5 seconds
         # With naive bilinear, the lat=0 land row pulls U down: at lat=0.1
         # (close to coast) U≈0.1*0.1≈0.01 deg/s, so dlon ≈ 0.05 over 5 s.
         dlon_unmasked = float(traj[-1, 0] - traj[0, 0])
@@ -528,8 +530,7 @@ class TestClosedBay:
     zero velocity (not NaN) and stay put."""
 
     def test_closed_bay_zero_velocity(self):
-        from pastax import Heun, solve
-        from pastax import Dataset
+        from pastax import Dataset, Heun, solve
         nlat, nlon, nt = 5, 5, 2
         lat = np.linspace(0.0, 4.0, nlat).astype(np.float32)
         lon = np.linspace(0.0, 4.0, nlon).astype(np.float32)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -38,13 +38,15 @@ class TestSolverStep:
     def test_euler_ode_step_constant_field(self):
         solver = Euler()
         y0 = jnp.array([0.0, 0.0])
-        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0, jnp.array(1.0), None, None)
+        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0,
+                             jnp.array(1.0), None, None)
         assert jnp.allclose(y1, jnp.array([0.1, 0.2]))
 
     def test_heun_ode_step_constant_field(self):
         solver = Heun()
         y0 = jnp.array([0.0, 0.0])
-        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0, jnp.array(1.0), None, None)
+        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0,
+                             jnp.array(1.0), None, None)
         assert jnp.allclose(y1, jnp.array([0.1, 0.2]))
 
     def test_euler_sde_step_zero_noise(self):
@@ -74,7 +76,8 @@ class TestSolverStep:
     def test_rk4_ode_step_constant_field(self):
         solver = RK4()
         y0 = jnp.array([0.0, 0.0])
-        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0, jnp.array(1.0), None, None)
+        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0,
+                             jnp.array(1.0), None, None)
         assert jnp.allclose(y1, jnp.array([0.1, 0.2]))
 
     def test_rk4_sde_step_zero_noise(self):
@@ -102,7 +105,8 @@ class TestSolveODE:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, 10.0
         T = n_save * int_dt
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0), n_save, int_dt, int_dt, Euler())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0),
+                     n_save, int_dt, int_dt, Euler())
         assert traj.shape == (n_save + 1, 2)
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) + dlat * T, rel=1e-4)
         assert float(traj[-1, 1]) == pytest.approx(float(y0[1]) + dlon * T, rel=1e-4)
@@ -112,7 +116,8 @@ class TestSolveODE:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, 10.0
         T = n_save * int_dt
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0), n_save, int_dt, int_dt, Heun())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0),
+                     n_save, int_dt, int_dt, Heun())
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) + dlat * T, rel=1e-5)
 
     def test_first_point_equals_y0(self):
@@ -203,7 +208,8 @@ class TestSolveODE:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, 10.0
         T = n_save * int_dt
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0), n_save, int_dt, int_dt, RK4())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0),
+                     n_save, int_dt, int_dt, RK4())
         assert traj.shape == (n_save + 1, 2)
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) + dlat * T, rel=1e-4)
         assert float(traj[-1, 1]) == pytest.approx(float(y0[1]) + dlon * T, rel=1e-4)
@@ -254,7 +260,8 @@ class TestSolveODE:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, -1.0
         T = abs(n_save * int_dt)
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(100.0), n_save, int_dt, int_dt, Heun())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(100.0),
+                     n_save, int_dt, int_dt, Heun())
         assert traj.shape == (n_save + 1, 2)
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) - dlat * T, rel=1e-5)
         assert float(traj[-1, 1]) == pytest.approx(float(y0[1]) - dlon * T, rel=1e-5)
@@ -425,7 +432,8 @@ class TestTsit5:
     def test_constant_field_step(self):
         solver = Tsit5()
         y0 = jnp.array([0.0, 0.0])
-        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0, jnp.array(1.0), None, None)
+        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0,
+                             jnp.array(1.0), None, None)
         assert jnp.allclose(y1, jnp.array([0.1, 0.2]))
 
     def test_uniform_field_solve(self):
@@ -433,7 +441,8 @@ class TestTsit5:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, 10.0
         T = n_save * int_dt
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0), n_save, int_dt, int_dt, Tsit5())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0),
+                     n_save, int_dt, int_dt, Tsit5())
         assert traj.shape == (n_save + 1, 2)
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) + dlat * T, rel=1e-4)
 
@@ -459,7 +468,8 @@ class TestDopri5:
     def test_constant_field_step(self):
         solver = Dopri5()
         y0 = jnp.array([0.0, 0.0])
-        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0, jnp.array(1.0), None, None)
+        y1 = solver.ode_step(uniform_ode_term(0.1, 0.2), jnp.array(0.0), y0,
+                             jnp.array(1.0), None, None)
         assert jnp.allclose(y1, jnp.array([0.1, 0.2]))
 
     def test_uniform_field_solve(self):
@@ -467,7 +477,8 @@ class TestDopri5:
         y0 = jnp.array([10.0, 20.0])
         n_save, int_dt = 100, 10.0
         T = n_save * int_dt
-        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0), n_save, int_dt, int_dt, Dopri5())
+        traj = solve(uniform_ode_term(dlat, dlon), y0, jnp.array(0.0),
+                     n_save, int_dt, int_dt, Dopri5())
         assert traj.shape == (n_save + 1, 2)
         assert float(traj[-1, 0]) == pytest.approx(float(y0[0]) + dlat * T, rel=1e-4)
 


### PR DESCRIPTION
## Problem

`ruff check src tests` reported 313 errors and nothing enforced it, so the count could only grow.

## Fix

- **283 were jaxtyping false positives**: shape annotations like `Float[Array, "time lat lon"]` trip F722 (forward-annotation syntax), F821 (undefined names from shape tokens under `from __future__ import annotations`), and UP037 (quoted-annotation removal, which would break the shape strings). These are now ignored in `[tool.ruff.lint]` with a comment linking the jaxtyping FAQ.
- **The ~30 genuine errors are fixed**: unused imports (`conftest`, a `TYPE_CHECKING` numpy), unsorted import blocks, `Callable` imported from `typing` instead of `collections.abc`, the eight `lambda` assignments in `_run_ode`/`_run_sde` converted to `def`s, one stray semicolon, and 19 long lines wrapped.
- The **Tests workflow now runs `ruff check src tests`** before pytest, so the repo stays clean.