### PR TITLE
Make the array loaders callable from inside a jit region

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -854,6 +854,16 @@ class Dataset(eqx.Module):
         )
 
 
+def _is_traced(x: Array) -> bool:
+    """True when ``x`` is an abstract JAX tracer (inside ``jit`` / ``vmap`` / ``grad``).
+
+    Host-side validation that must read concrete values (a ``bool(...)`` on an
+    array) is skipped when this returns ``True`` so the loaders stay callable
+    from within a traced region; the caller then owns coordinate correctness.
+    """
+    return isinstance(x, jax.core.Tracer)
+
+
 def _check_periodic_lon_ascending(
     lon_arr: Float[Array, "lon"], lon_period: float | None
 ) -> None:
@@ -863,8 +873,14 @@ def _check_periodic_lon_ascending(
     ``lon_coords[0]``, which assumes an ascending axis; a descending axis
     silently produces wrong indices and weights. (Without ``lon_period``,
     descending coordinates work — the spacing sign cancels.)
+
+    The check reads concrete values, so it is a no-op when ``lon_arr`` is a
+    tracer (the loader was called from inside ``jit`` / ``vmap``): correctness
+    of the coordinate axis is then the caller's responsibility.
     """
     if lon_period is None:
+        return
+    if _is_traced(lon_arr):
         return
     if not bool(jnp.all(jnp.diff(lon_arr) > 0)):
         raise ValueError(
@@ -909,6 +925,13 @@ def _resolve_mask(
        Field is bit-exact identical (PyTree structure included) to one
        built before the mask feature was added.
 
+    NaN-mask inference (step 3) reads concrete values *and* would make the
+    returned PyTree structure data-dependent (``mask=None`` vs a bool array),
+    which is illegal under tracing. It is therefore skipped when ``values`` is
+    a tracer: the NaN→0 replacement still happens (a safe traced op), but the
+    mask is left ``None`` unless an explicit ``user_mask`` is given. Pass
+    ``masks=`` when building a Dataset from inside ``jit`` and you need coasts.
+
     Returns:
         ``(clean_values, mask)`` where ``mask`` is either a 2-D bool array
         or ``None``.
@@ -925,6 +948,9 @@ def _resolve_mask(
                 "(wet-and-dry) are not supported."
             )
         return clean_values, mask
+
+    if _is_traced(values):
+        return clean_values, None
 
     if bool(nan_locs.any()):
         inferred = nan_locs.any(axis=0)

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -763,8 +763,82 @@ class TestPeriodicLonAscending:
                 vectors={"current": {"u": ("uo", u), "v": ("vo", v)}},
                 lon_period=360.0,
             )
-            
-            
+
+
+class TestLoadersAreTracerSafe:
+    """The loaders must be callable from inside a traced (jit/vmap) region.
+
+    Host-side validations that read concrete values (the ascending-lon check
+    and NaN-mask inference) are skipped under tracing; the caller then owns
+    coordinate correctness and passes explicit masks when needed.
+    """
+
+    _lat = np.array([0.0, 1.0, 2.0, 3.0])
+    _lon = np.array([0.0, 90.0, 180.0, 270.0])
+    _t = np.array([0.0, 3600.0])
+
+    def test_from_arrays_jit_with_lon_period(self):
+        u = np.ones((2, 4, 4), dtype=np.float32)
+
+        def build_and_interp(u, lon, q):
+            ds = Dataset.from_arrays(
+                {"u": u}, t=self._t, lat=self._lat, lon=lon, lon_period=360.0
+            )
+            return ds["u"].interp(jnp.array(0.0), q, jnp.array(1.0))
+
+        v = jax.jit(build_and_interp)(
+            jnp.asarray(u), jnp.asarray(self._lon), jnp.array(315.0)
+        )
+        assert float(v) == pytest.approx(1.0, abs=1e-6)
+
+    def test_from_arrays_jit_nan_zeroed_mask_deferred(self):
+        u = np.ones((2, 4, 4), dtype=np.float32)
+        u[:, 0, 0] = np.nan  # would infer a mask eagerly
+
+        def total(u):
+            ds = Dataset.from_arrays({"u": u}, t=self._t, lat=self._lat, lon=self._lon)
+            return ds["u"].values.sum()
+
+        # NaN is still replaced with 0 under trace (2 cells) → 32 - 2 = 30.
+        assert float(jax.jit(total)(jnp.asarray(u))) == pytest.approx(30.0)
+
+        # Eager on the same input still infers the mask (structure differs).
+        eager = Dataset.from_arrays(
+            {"u": u}, t=self._t, lat=self._lat, lon=self._lon
+        )
+        assert eager["u"].mask is not None
+
+    def test_from_arrays_jit_with_explicit_mask(self):
+        u = np.ones((2, 4, 4), dtype=np.float32)
+        m = np.zeros((4, 4), dtype=bool)
+        m[0, 0] = True
+
+        def build(u, mask):
+            ds = Dataset.from_arrays(
+                {"u": u}, t=self._t, lat=self._lat, lon=self._lon, masks={"u": mask}
+            )
+            return ds["u"].mask
+
+        out = jax.jit(build)(jnp.asarray(u), jnp.asarray(m))
+        assert bool(out[0, 0]) is True
+
+    def test_from_arrays_cgrid_jit(self):
+        clat = np.linspace(0.0, 4.0, 5)
+        clon = np.linspace(0.0, 5.0, 6)
+        uc = np.ones((2, 5, 5), dtype=np.float32)
+        vc = np.ones((2, 4, 6), dtype=np.float32)
+
+        def build(uc, vc):
+            ds = Dataset.from_arrays_cgrid(
+                self._t, clat, clon,
+                vectors={"current": {"u": ("u", uc), "v": ("v", vc)}},
+            )
+            return ds["u"].interp(jnp.array(0.0), jnp.array(2.5), jnp.array(2.0))
+
+        v = jax.jit(build)(jnp.asarray(uc), jnp.asarray(vc))
+        assert float(v) == pytest.approx(1.0, abs=1e-6)
+
+
 class TestFromArraysShapeValidation:
     def _coords(self):
         t   = np.linspace(0.0, 3 * 3600.0, 4)


### PR DESCRIPTION
## Problem

`Dataset.from_arrays` / `from_arrays_cgrid` raised `TracerBoolConversionError` when called from inside a `jit` / `vmap` region. Two host-side inspections force concretization via `bool(...)`:

1. the ascending-longitude check added in #12 for `lon_period` (`bool(jnp.all(jnp.diff(lon) > 0))`), and
2. the pre-existing NaN-mask inference in `_resolve_mask` (`bool(nan_locs.any())`).

Both blow up on traced coordinate/value arrays.

## Fix

A tiny `_is_traced(x)` helper (`isinstance(x, jax.core.Tracer)`) gates both checks so they run **only outside traced code**:

- **Ascending-lon check:** a no-op under tracing — the caller owns coordinate correctness, exactly as requested. Concrete construction still validates.
- **NaN-mask inference:** skipped under tracing. Inferring a mask from values would also make the returned PyTree structure data-dependent (`mask=None` vs a bool array), which is illegal under `jit`, so under tracing the mask stays `None`. The `NaN → 0` replacement (a safe traced op) still happens. Pass an explicit `masks=` when you build a `Dataset` under `jit` and need coasts.

Eager construction is unchanged: descending periodic longitudes still raise, and NaN still infers a mask.

## Tests

New `TestLoadersAreTracerSafe`: `from_arrays` under `jit` with `lon_period` + `interp`; NaN inputs zeroed with the mask deferred to `None` under `jit` (while eager still infers it); explicit mask threaded through `jit`; and `from_arrays_cgrid` under `jit`.