### PR TITLE
Make variogram_score gradients finite for p < 1

### DIFF
--- a/src/pastax/score.py
+++ b/src/pastax/score.py
@@ -55,6 +55,21 @@ def l2_distance(
     return safe_sqrt(jnp.sum((x - y) ** 2, axis=-1))
 
 
+def _safe_abs_pow(x: Float[Array, "..."], p: float) -> Float[Array, "..."]:
+    r"""Gradient-safe :math:`|x|^p`.
+
+    ``|x| ** p`` has an unbounded derivative at ``x = 0`` for ``p < 1``
+    (:math:`p\,|x|^{p-1} \to \infty`), which turns into ``nan`` in the
+    backward pass — and a ``0 * nan`` further down (e.g. a zero
+    ``component_weights`` entry in :func:`variogram_score`) stays ``nan``.
+    The standard "double where" trick evaluates the power only where
+    ``x != 0`` so the value is unchanged (``|0|^p == 0`` for ``p > 0``)
+    while the gradient at exact zeros is ``0`` instead of ``nan``.
+    """
+    mask = x != 0.0
+    return jnp.where(mask, jnp.abs(jnp.where(mask, x, 1.0)) ** p, 0.0)
+
+
 def _reduce(
     score_per_t: Float[Array, " T"],
     reduce: Reduce,
@@ -229,7 +244,11 @@ def variogram_score(
     Args:
         forecast: Ensemble forecast, shape ``(S, T, 2)``.
         obs: Observed trajectory, shape ``(T, 2)``.
-        p: Variogram order. Default ``2.0``.
+        p: Variogram order. Default ``2.0``. Any ``p > 0`` is
+            gradient-safe: the powers are evaluated through a "double
+            where" so exactly-zero differences (the component diagonal,
+            or ties in the data) contribute a zero gradient instead of
+            ``nan`` when ``p < 1``.
         component_weights: ``(2, 2)`` non-negative weight matrix. Defaults to
             ``ones((2, 2)) - eye(2)``.
         reduce: See :func:`squared_error`.
@@ -241,9 +260,9 @@ def variogram_score(
     if component_weights is None:
         component_weights = jnp.ones((2, 2)) - jnp.eye(2)
 
-    diff_fcst = jnp.abs(forecast[..., :, None] - forecast[..., None, :]) ** p
+    diff_fcst = _safe_abs_pow(forecast[..., :, None] - forecast[..., None, :], p)
     ex_fcst = diff_fcst.mean(axis=0)
-    diff_obs = jnp.abs(obs[..., :, None] - obs[..., None, :]) ** p
+    diff_obs = _safe_abs_pow(obs[..., :, None] - obs[..., None, :], p)
     residual = ex_fcst - diff_obs
 
     score_per_t = (component_weights * residual ** 2).sum(axis=(-2, -1))

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -357,6 +357,38 @@ class TestVariogramScore:
         b = jax.jit(variogram_score)(f, o)
         assert jnp.allclose(a, b)
 
+    @pytest.mark.parametrize("p", [0.5, 1.0])
+    def test_grad_finite_for_p_below_two(self, p):
+        """|x|^p has an unbounded derivative at x=0 for p < 1; the component
+        diagonal is exactly zero, so without the double-where trick the
+        backward pass produced nan (0 * inf survives the zero weights)."""
+        key = jax.random.key(24)
+        f = jax.random.normal(key, (6, 3, 2))
+        o = jnp.zeros((3, 2))
+        g = jax.grad(lambda a: variogram_score(a, o, p=p, reduce="sum"))(f)
+        assert jnp.all(jnp.isfinite(g))
+
+    def test_grad_finite_with_ties_in_forecast(self):
+        """Exactly tied ensemble members create off-diagonal zero differences
+        too; gradients must stay finite there as well."""
+        f = jnp.array([[[1.0, 1.0]], [[1.0, 2.0]]])  # components tied in member 0
+        o = jnp.array([[0.0, 1.0]])
+        g = jax.grad(lambda a: variogram_score(a, o, p=0.5, reduce="sum"))(f)
+        assert jnp.all(jnp.isfinite(g))
+
+    def test_value_unchanged_by_safe_pow(self):
+        """The double-where rewrite must not change forward values."""
+        key = jax.random.key(25)
+        f = jax.random.normal(key, (6, 3, 2))
+        o = jax.random.normal(jax.random.key(26), (3, 2))
+        for p in (0.5, 1.0, 2.0):
+            expected = (
+                ((jnp.abs(f[..., :, None] - f[..., None, :]) ** p).mean(0)
+                 - jnp.abs(o[..., :, None] - o[..., None, :]) ** p) ** 2
+                * (jnp.ones((2, 2)) - jnp.eye(2))
+            ).sum(axis=(-2, -1))
+            assert jnp.allclose(variogram_score(f, o, p=p), expected, atol=1e-6)
+
 
 def test_reduce_invalid_value_raises():
     f = jnp.ones((3, 2, 2))


### PR DESCRIPTION
## Problem

`|x| ** p` has an unbounded derivative at `x = 0` for `p < 1`, which becomes `nan` in the backward pass. The component diagonal of the pairwise differences in `variogram_score` is *exactly* zero, and the zero diagonal of `component_weights` does not save it — `0 * nan` is still `nan` — so any `p < 1` poisoned the entire gradient. Exactly tied values (off-diagonal zeros) triggered the same failure.

## Fix

Evaluate the powers through the "double where" trick (the same idiom `_safe_math` uses), via a new `_safe_abs_pow` helper: forward values are unchanged (`|0|^p == 0` for `p > 0`) and exact-zero differences now contribute a zero gradient instead of `nan`. Documented on the `p` argument.

## Tests

- `test_grad_finite_for_p_below_two` (parametrized `p=0.5`, `p=1.0`): gradient is finite; failed with `nan` before the fix for `p=0.5`.
- `test_grad_finite_with_ties_in_forecast`: off-diagonal exact ties also stay finite.
- `test_value_unchanged_by_safe_pow`: forward values bit-match the naive formula for `p ∈ {0.5, 1, 2}`.

Full suite passes (317).