### PR TITLE
Import DTypeLike from jax.typing

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -14,7 +14,7 @@ from .interpolation import spatiotemporal_interp, spatiotemporal_velocity_partia
 
 if TYPE_CHECKING:
     import xarray as xr
-    from jax import DTypeLike
+    from jax.typing import DTypeLike
 
 __all__ = ["Field", "Dataset"]
 


### PR DESCRIPTION
## Problem

`from jax import DTypeLike` is not a valid import — the alias lives in `jax.typing`. It only went unnoticed because the import sits under `TYPE_CHECKING` (so it never executes at runtime), but pyright resolves it as an error and the `dtype` parameter annotations on all four loaders as `Unknown`.

## Fix

Import from `jax.typing` instead. One-line change; verified the import is valid against the installed JAX and the loaders' tests pass.