### PR TITLE
Trim stale conftest comment about 64-bit floats

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
 import jax
 
-# Use CPU and 64-bit floats for test precision
+# Run the test suite on CPU
 jax.config.update("jax_platform_name", "cpu")


### PR DESCRIPTION
The comment in `tests/conftest.py` claimed the suite runs with "64-bit floats for test precision", but `jax_enable_x64` is never enabled — only the CPU platform is configured. The comment now says what the code does. No behaviour change.