### PR TITLE
Zero values under user-supplied land masks

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -912,8 +912,12 @@ def _resolve_mask(
 
     1. NaN values are always replaced with 0 in the returned values array.
     2. If ``user_mask`` is provided, it is validated against
-       ``expected_mask_shape`` and used as-is. Time-varying (3-D) masks are
-       rejected.
+       ``expected_mask_shape`` and used as-is, and the values under the mask
+       are zeroed. Datasets that flag land with a fill value (e.g. ``1e20``)
+       instead of NaN would otherwise leak those fill values into the
+       interpolation paths that still read land corners (the partial-slip
+       naive fallback and its all-corners-land case). Time-varying (3-D)
+       masks are rejected.
     3. Otherwise, if NaN was present in ``values``, infer a 2-D mask from
        ``isnan(values).any(axis=0)``. Cells that are NaN at *some but not
        all* time steps are almost certainly missing data (sensor gaps)
@@ -947,6 +951,9 @@ def _resolve_mask(
                 f"{expected_mask_shape}, got {mask.shape}. Time-varying masks "
                 "(wet-and-dry) are not supported."
             )
+        clean_values = jnp.where(
+            mask, jnp.asarray(0.0, dtype=clean_values.dtype), clean_values
+        )
         return clean_values, mask
 
     if _is_traced(values):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -95,6 +95,25 @@ class TestFromArraysMask:
         # NaN was still cleared from values regardless.
         assert bool(jnp.isnan(ds["u"].values).any()) is False
 
+    def test_user_mask_zeroes_fill_values(self):
+        """Values under an explicit mask are zeroed, even when not NaN.
+
+        Datasets flagging land with a fill value (e.g. 1e20) instead of NaN
+        must not leak that fill value into the interpolation paths that still
+        read land corners (partial-slip naive fallback, all-corners-land).
+        """
+        t, lat, lon = self._coords()
+        u = np.ones((3, 4, 5), dtype=np.float32)
+        u[:, 0, 0] = 1e20         # fill value marking land, no NaN
+        explicit = np.zeros((4, 5), dtype=bool)
+        explicit[0, 0] = True
+        ds = Dataset.from_arrays(
+            {"u": u}, t=t, lat=lat, lon=lon, masks={"u": explicit},
+        )
+        assert float(ds["u"].values[0, 0, 0]) == 0.0
+        # Ocean cells are untouched.
+        assert float(ds["u"].values[0, 1, 1]) == 1.0
+
     def test_per_field_mask_routing(self):
         t, lat, lon = self._coords()
         u = np.ones((3, 4, 5), dtype=np.float32)


### PR DESCRIPTION
## Problem

`_resolve_mask` zero-fills NaN values, but values under an *explicit* user mask were kept as-is. Datasets that flag land with a fill value (e.g. `1e20`) instead of NaN leaked those fill values into the interpolation paths that still read land corners:

- the partial-slip naive fallback (e.g. a cell whose west edge only is land for U), and
- its all-corners-land case, which averages the four corner values.

## Fix

Zero the values under a user-supplied mask in `_resolve_mask`, matching the NaN-inferred behaviour where masked cells are always zero-filled. Documented in the function's rule list.

## Tests

`test_user_mask_zeroes_fill_values`: builds a field with a `1e20` fill value under an explicit mask and asserts the stored value is `0.0` while ocean cells are untouched.