### PR TITLE
Guard partialslip against face-staggered fields, not just C-grid datasets

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -401,7 +401,15 @@ class Dataset(eqx.Module):
             return jnp.stack([u, v])
 
         if scheme == "partialslip":
-            if self.grid is not None and self.grid.stagger_type == "C":
+            # Check the fields' stagger roles, not just the dataset-level
+            # grid: a Dataset built directly (grid=None) around face-staggered
+            # fields must not fall through to the A-grid maths below, which
+            # would read V values on U-face coordinates.
+            if (
+                (self.grid is not None and self.grid.stagger_type == "C")
+                or u_field.stagger != "center"
+                or v_field.stagger != "center"
+            ):
                 raise NotImplementedError(
                     "scheme='partialslip' is not implemented for Arakawa "
                     "C-grid datasets. Use scheme='default' (per-Field "

--- a/tests/test_velocity_interp.py
+++ b/tests/test_velocity_interp.py
@@ -199,6 +199,27 @@ class TestPartialSlipErrors:
                 scheme="partialslip",
             )
 
+    def test_c_grid_fields_raise_even_without_dataset_grid(self):
+        """A Dataset built directly (grid=None) around face-staggered fields
+        must still be rejected: the A-grid partial-slip maths would read V
+        values on U-face coordinates."""
+        nlat, nlon, nt = 5, 6, 2
+        lat = np.linspace(0.0, 4.0, nlat).astype(np.float32)
+        lon = np.linspace(0.0, 5.0, nlon).astype(np.float32)
+        t = np.array([0.0, 1.0], dtype=np.float32)
+        u_data = np.zeros((nt, nlat, nlon - 1), dtype=np.float32)
+        v_data = np.zeros((nt, nlat - 1, nlon), dtype=np.float32)
+        cgrid = Dataset.from_arrays_cgrid(
+            t, lat, lon,
+            {"current": {"u": ("u", u_data), "v": ("v", v_data)}},
+        )
+        ds = Dataset(fields=cgrid.fields, grid=None)
+        with pytest.raises(NotImplementedError, match="C-grid"):
+            ds.velocity_interp(
+                jnp.asarray(0.0), jnp.asarray(2.5), jnp.asarray(2.0),
+                scheme="partialslip",
+            )
+
     def test_partialslip_without_mask_raises(self):
         ds = _agrid_dataset(with_mask=False, land_row=False)
         with pytest.raises(ValueError, match="land mask"):


### PR DESCRIPTION
## Problem

`velocity_interp(scheme="partialslip")` rejects C-grid forcing by checking `self.grid.stagger_type == "C"` — but `Dataset(fields=..., grid=None)` is an accepted construction (`grid` defaults to `None`). A dataset built that way around face-staggered fields slipped past the guard, and the A-grid partial-slip maths then silently read **V values on U-face coordinates** (the joint call uses the U field's coordinates for both components).

## Fix

Also check the U/V fields' own `stagger` roles, which hold regardless of how the `Dataset` was constructed. The dataset-level check is kept so C-grid datasets keep raising even when the named fields are centre tracers.

## Tests

`test_c_grid_fields_raise_even_without_dataset_grid`: rebuilds a C-grid dataset's fields into a `Dataset(grid=None)` and asserts `NotImplementedError` is still raised.