### PR TITLE
Undo the rebasing of datetime64 time coordinates to the first timestamp

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -19,21 +19,14 @@ if TYPE_CHECKING:
 __all__ = ["Field", "Dataset"]
 
 
-def _coerce_time_to_seconds(t: Array) -> tuple[Array, Array]:
+def _coerce_time_to_seconds(t: Array) -> Array:
     """Convert a datetime64 time coordinate to relative seconds; pass-through otherwise.
 
     Both ``Dataset.from_arrays`` and ``Dataset.from_xarray`` route through this
     helper, so users may pass NumPy ``datetime64`` arrays (any unit) directly:
-    they are converted to **seconds since the first timestamp** and the first
-    timestamp itself (as seconds since the Unix epoch) is returned separately
-    as ``t_origin``. Rebasing keeps the stored coordinates small — epoch-scale
-    values (~1.7e9 s) are unrepresentable in float32 beyond a 128 s
-    granularity, which would silently quantize interpolation weights.
+    they are converted to seconds since the Unix epoch.
 
-    Plain numeric arrays are returned unchanged with ``t_origin = 0`` and are
-    treated as "seconds since some user-chosen reference" (the user owns the
-    frame; pick a reference near the data, not the Unix epoch, when running in
-    float32).
+    Plain numeric arrays are returned unchanged.
 
     JAX arrays (concrete or traced) are passed straight through: JAX has no
     ``datetime64`` dtype, so there is nothing to coerce, and this keeps the
@@ -41,17 +34,12 @@ def _coerce_time_to_seconds(t: Array) -> tuple[Array, Array]:
     (``np.asarray`` on a tracer would raise).
 
     Returns:
-        ``(t_seconds, t_origin)`` where ``t_seconds`` is the (possibly rebased)
-        time coordinate array and ``t_origin`` is the epoch offset as a 0-d
-        NumPy ``int64`` array (``0`` unless the input was ``datetime64``).
-        Integer seconds are exact in int64, and the value is a pytree *leaf*
-        on :class:`Grid` — not static metadata — so datasets differing only
-        in ``t_origin`` do not retrigger jit compilation.
+        ``t_seconds`` the time coordinate array.
     """
     import numpy as np
 
     if isinstance(t, jax.Array):
-        return t, np.array(0, dtype=np.int64)
+        return t
 
     # The ``Array`` annotation aliases ``jax.Array``, so type checkers flag the
     # lines below as unreachable. They are not: at runtime ``t`` is often a
@@ -60,9 +48,8 @@ def _coerce_time_to_seconds(t: Array) -> tuple[Array, Array]:
     t_arr = np.asarray(t)
     if t_arr.dtype.kind == "M":
         secs = t_arr.astype("datetime64[s]").astype(np.int64)
-        origin = int(secs[0]) if secs.size else 0
-        return secs - origin, np.array(origin, dtype=np.int64)
-    return t_arr, np.array(0, dtype=np.int64)
+        return secs
+    return t_arr
 
 
 def _nearest_idx(coords: Float[Array, "n"], x: Float[Array, ""], n: int) -> Array:
@@ -443,19 +430,15 @@ class Dataset(eqx.Module):
         Args:
             fields: Mapping {field_name: array of shape (time, lat, lon)}.
             t: 1-D time coordinate array. Either equally-spaced numeric values
-                (seconds since an arbitrary reference) or a NumPy ``datetime64``
+                (seconds since the Unix epoch) or a NumPy ``datetime64``
                 array (any unit); the latter is auto-converted to seconds
-                **relative to the first timestamp**, with the first timestamp
-                stored as ``Grid.t_origin`` (a 0-d int64 array of seconds
-                since the Unix epoch — a pytree leaf, so changing forcing
-                origins does not retrigger jit compilation).
-                Rebasing keeps float32 time coordinates precise — raw
-                epoch-scale seconds (~1.7e9) have a 128 s float32 granularity.
-                Numeric input is used as-is: choose a reference near the data
-                rather than the Unix epoch when running in float32.
+                relative to the Unix epoch.
+                Numeric input is used as-is.
+                Double precision should be used to avoid truncation errors.
             lat: 1-D latitude coordinate array (degrees), equally spaced.
             lon: 1-D longitude coordinate array (degrees), equally spaced.
-            dtype: JAX dtype for all arrays (default float32).
+            dtype: JAX dtype for all arrays, except for the time coordinate 
+                (default float32).
             lon_period: If set (e.g. ``360.0``), all fields are constructed
                 with periodic longitude wrapping. The grid must span exactly
                 one period.
@@ -471,8 +454,8 @@ class Dataset(eqx.Module):
         Returns:
             Dataset with all fields on the given grid.
         """
-        t, t_origin = _coerce_time_to_seconds(t)
-        t_arr   = jnp.asarray(t,   dtype=dtype)
+        t = _coerce_time_to_seconds(t)
+        t_arr   = jnp.asarray(t,   dtype=jnp.int64)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
         _check_periodic_lon_ascending(lon_arr, lon_period)
@@ -486,7 +469,6 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="A",
             lon_period=lon_period,
-            t_origin=t_origin,
         )
         masks = masks or {}
         unknown = set(masks) - set(fields)
@@ -544,9 +526,6 @@ class Dataset(eqx.Module):
 
         Returns:
             Dataset with all fields loaded into host memory as JAX arrays.
-            ``datetime64`` time coordinates are rebased to seconds since the
-            first timestamp (kept as ``Grid.t_origin``); solver times must use
-            the same rebased frame (see :meth:`from_arrays`).
         """
         field_arrays = {
             internal: ds[xr_name].values for internal, xr_name in fields.items()
@@ -593,9 +572,6 @@ class Dataset(eqx.Module):
 
         Args:
             t: 1-D time coordinates (seconds or NumPy ``datetime64``).
-                ``datetime64`` input is rebased to seconds since the first
-                timestamp, stored as ``Grid.t_origin`` (see
-                :meth:`from_arrays`).
             center_lat: 1-D centre latitudes (degrees), equally spaced.
             center_lon: 1-D centre longitudes (degrees), equally spaced.
             vectors: Mapping ``{group_name: {"u": (field_name, u_array),
@@ -652,8 +628,8 @@ class Dataset(eqx.Module):
                 "an empty 'vectors' mapping."
             )
 
-        t, t_origin = _coerce_time_to_seconds(t)
-        t_arr   = jnp.asarray(t,           dtype=dtype)
+        t = _coerce_time_to_seconds(t)
+        t_arr   = jnp.asarray(t,           dtype=jnp.int64)
         lat_arr = jnp.asarray(center_lat,  dtype=dtype)
         lon_arr = jnp.asarray(center_lon,  dtype=dtype)
         _check_periodic_lon_ascending(lon_arr, lon_period)
@@ -669,7 +645,6 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="C",
             lon_period=lon_period,
-            t_origin=t_origin,
         )
         derived_u_lat, derived_u_lon = centre_grid.u_face_coords()
         derived_v_lat, derived_v_lon = centre_grid.v_face_coords()
@@ -692,7 +667,6 @@ class Dataset(eqx.Module):
             grid_type="rectilinear",
             stagger_type="C",
             lon_period=lon_period,
-            t_origin=t_origin,
             u_lat_coords=u_lat_arr,
             u_lon_coords=u_lon_arr,
             v_lat_coords=v_lat_arr,

--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -248,7 +248,7 @@ class Field(eqx.Module):
         ilon = _nearest_idx_periodic(self.lon_coords, lon, nlon, self.lon_period)
         block = jax.lax.dynamic_slice(
             self.values,
-            (it_start, ilat_start, 0),
+            (it_start, ilat_start, jnp.astype(0, jnp.int32)),
             (wt, wlat, nlon),
         )
         lon_idx = (ilon - lon_window + jnp.arange(wlon)) % nlon

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -22,9 +22,8 @@ from typing import Literal
 
 import equinox as eqx
 import jax.numpy as jnp
-import numpy as np
 
-from ._types import Array, Float, Int
+from ._types import Array, Float
 
 __all__ = ["Grid"]
 

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -47,21 +47,6 @@ class Grid(eqx.Module):
         lon_period: If set (e.g. ``360.0``), longitude is treated as periodic
             with that period. The centre grid is assumed to span exactly one
             period.
-        t_origin: Epoch offset of the time axis, in seconds since the Unix
-            epoch, stored as a 0-d ``int64`` array. ``t_coords`` are relative
-            to this instant, i.e. the absolute time of ``t_coords[i]`` is
-            ``t_origin + t_coords[i]``. Loaders set it when converting
-            ``datetime64`` input (which is rebased to the first timestamp so
-            the stored float32 coordinates stay small and precise); it is
-            ``0`` for plain numeric time input. Solver times (``t0`` and
-            interpolation queries) live in the same rebased frame.
-
-            ``t_origin`` is a pytree *leaf*, not static metadata: swapping
-            forcing datasets with different origins does not retrigger jit
-            compilation. Integer seconds are exact in int64; read the value
-            host-side with ``int(grid.t_origin)``. Inside ``jax.jit`` (without
-            ``jax_enable_x64``) the leaf is canonicalized to int32, which
-            remains exact for epoch seconds until 2038.
         u_lat_coords, u_lon_coords: U-face coordinates (NEMO C-grid). Populated
             by the C-grid loaders (derived from the centre grid via
             :meth:`u_face_coords` or supplied explicitly); ``None`` on A-grids.
@@ -78,9 +63,6 @@ class Grid(eqx.Module):
     )
     stagger_type: Literal["A", "C"] = eqx.field(static=True, default="A")
     lon_period: float | None = eqx.field(static=True, default=None)
-    t_origin: Int[Array, ""] = eqx.field(
-        default_factory=lambda: np.array(0, dtype=np.int64)
-    )
     u_lat_coords: Float[Array, "..."] | None = None
     u_lon_coords: Float[Array, "..."] | None = None
     v_lat_coords: Float[Array, "..."] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import jax
 
 # Use CPU and 64-bit floats for test precision
+jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -262,8 +262,6 @@ class TestDatasetFromArrays:
             dataset["u"].t_coords,
             jnp.asarray(expected, dtype=dataset["u"].t_coords.dtype),
         )
-        assert int(dataset.grid.t_origin) == int(epoch[0])
-        assert dataset.grid.t_origin.dtype == np.int64
 
     def test_datetime64_rebasing_preserves_float32_precision(self):
         """Hourly datetime64 coords at a 2026 epoch stay exact in float32.
@@ -291,98 +289,6 @@ class TestDatasetFromArrays:
         # Mid-cell query: exactly half-way between hours 1 and 2.
         v = dataset["u"].interp(jnp.array(5400.0), jnp.array(11.0), jnp.array(1.0))
         assert float(v) == pytest.approx(1.5, abs=1e-6)
-
-    def test_different_t_origin_does_not_retrace_jit(self):
-        """t_origin is a pytree leaf: swapping forcing origins must not recompile."""
-
-        def build(day):
-            t_dt = np.arange(
-                np.datetime64(day),
-                np.datetime64(day) + np.timedelta64(4, "h"),
-                np.timedelta64(1, "h"),
-            )
-            lat = np.linspace(0.0, 3.0, 4)
-            lon = np.linspace(10.0, 13.0, 4)
-            u = np.ones((4, 4, 4), dtype=np.float32)
-            return Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
-
-        traces = {"n": 0}
-
-        @jax.jit
-        def f(ds):
-            traces["n"] += 1  # runs at trace time only
-            return ds["u"].interp(jnp.array(1800.0), jnp.array(11.0), jnp.array(1.0))
-
-        v1 = f(build("2026-07-01T00:00"))
-        v2 = f(build("2026-09-01T00:00"))  # same shapes, different t_origin
-        assert traces["n"] == 1
-        assert float(v1) == pytest.approx(float(v2))
-
-    def test_t_origin_traces_through_solve_without_recompiling(self):
-        """t_origin flows into the solver term as a traced value, not a constant.
-
-        The absolute epoch time ``t + grid.t_origin`` (the month-of-year use
-        case) is recovered inside the term and drives a seasonal signal. A
-        single jitted program must:
-
-        * trace exactly once across datasets with different ``t_origin`` and a
-          changed ``t0`` (no recompilation), and
-        * still produce *different* trajectories for different origins —
-          proving ``t_origin`` is a runtime input threaded all the way into
-          the term, not baked into the trace as a constant.
-        """
-        from pastax import Euler
-
-        def build(day):
-            t_dt = np.arange(
-                np.datetime64(day),
-                np.datetime64(day) + np.timedelta64(6, "h"),
-                np.timedelta64(1, "h"),
-            )
-            lat = np.linspace(0.0, 3.0, 4)
-            lon = np.linspace(10.0, 13.0, 4)
-            u = np.ones((6, 4, 4), dtype=np.float32)
-            v = np.zeros((6, 4, 4), dtype=np.float32)
-            return Dataset.from_arrays({"u": u, "v": v}, t=t_dt, lat=lat, lon=lon)
-
-        year = 365.25 * 86400.0
-
-        def term(t, y, args):
-            ds = args
-            abs_t = t + ds.grid.t_origin  # absolute epoch seconds (traced leaf)
-            season = jnp.sin(2.0 * jnp.pi * abs_t / year)
-            u = ds["u"].interp(t, y[0], y[1])
-            v = ds["v"].interp(t, y[0], y[1])
-            return jnp.array([u, v]) + 1e-3 * season
-
-        traces = {"n": 0}
-
-        @jax.jit
-        def run(ds, t0):
-            traces["n"] += 1  # trace-time only
-            return solve(
-                term, jnp.array([11.0, 1.0]), t0,
-                n_save=3, int_dt=3600.0, save_dt=3600.0,
-                solver=Euler(), args=ds,
-            )
-
-        r_jul = run(build("2026-07-01T00:00"), jnp.array(0.0))
-        r_sep = run(build("2026-09-01T00:00"), jnp.array(0.0))  # different origin
-        _ = run(build("2026-07-01T00:00"), jnp.array(3600.0))   # different t0
-
-        assert traces["n"] == 1  # no recompilation
-        assert jnp.all(jnp.isfinite(r_jul)) and jnp.all(jnp.isfinite(r_sep))
-        # Different origins → different seasonal phase → different trajectory,
-        # so t_origin genuinely reached the term as a runtime value.
-        assert not jnp.allclose(r_jul, r_sep)
-
-    def test_numeric_time_passes_through_unrebased(self):
-        """Plain numeric time input keeps its frame and t_origin stays 0."""
-        t, lat, lon = self._coords()
-        u = np.ones((4, 4, 4), dtype=np.float32)
-        dataset = Dataset.from_arrays({"u": u}, t=t + 123.0, lat=lat, lon=lon)
-        assert int(dataset.grid.t_origin) == 0
-        assert float(dataset["u"].t_coords[0]) == pytest.approx(123.0)
 
     def test_from_arrays_datetime64_matches_from_xarray(self):
         """from_arrays with datetime64 and from_xarray must yield identical t_coords."""
@@ -618,11 +524,6 @@ class TestDatasetCGrid:
         assert jnp.allclose(from_xr["v"].values, from_arr["v"].values)
         assert jnp.allclose(from_xr["u"].lon_coords, from_arr["u"].lon_coords)
         assert jnp.allclose(from_xr["v"].lat_coords, from_arr["v"].lat_coords)
-        # datetime64 time is rebased identically on both paths.
-        epoch0 = int(t.astype("datetime64[s]").astype(np.int64)[0])
-        assert int(from_xr.grid.t_origin) == epoch0
-        assert int(from_arr.grid.t_origin) == epoch0
-        assert float(from_xr.grid.t_coords[0]) == 0.0
 
     def test_from_xarray_cgrid_with_explicit_staggered_coords(self):
         t = np.linspace(0.0, 7200.0, 3)

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -250,45 +250,17 @@ class TestDatasetFromArrays:
         assert float(v) == pytest.approx(1.5)
 
     def test_from_arrays_accepts_datetime64(self):
-        """datetime64 time is rebased to seconds since the first timestamp."""
+        """datetime64 time is rebased to seconds since the Unix epoch."""
         t_dt = np.array(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"],
                         dtype="datetime64[D]")
         _, lat, lon = self._coords()
         u = np.ones((4, 4, 4), dtype=np.float32)
         dataset = Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
         epoch = t_dt.astype("datetime64[s]").astype(np.int64)
-        expected = epoch - epoch[0]
         assert jnp.allclose(
             dataset["u"].t_coords,
-            jnp.asarray(expected, dtype=dataset["u"].t_coords.dtype),
+            jnp.asarray(epoch, dtype=dataset["u"].t_coords.dtype),
         )
-
-    def test_datetime64_rebasing_preserves_float32_precision(self):
-        """Hourly datetime64 coords at a 2026 epoch stay exact in float32.
-
-        Raw epoch seconds (~1.77e9) have a 128 s float32 granularity, so
-        without rebasing hourly steps cannot be represented and interpolation
-        weights are quantized. After rebasing, coords are small integers and
-        a mid-cell time query interpolates exactly.
-        """
-        t_dt = np.arange(
-            np.datetime64("2026-07-01T00:00:00"),
-            np.datetime64("2026-07-01T04:00:00"),
-            np.timedelta64(1, "h"),
-        )
-        lat = np.linspace(0.0, 3.0, 4)
-        lon = np.linspace(10.0, 13.0, 4)
-        # Field value equals the hour index at every grid point.
-        u = np.broadcast_to(
-            np.arange(4, dtype=np.float32)[:, None, None], (4, 4, 4)
-        )
-        dataset = Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
-        assert jnp.array_equal(
-            dataset["u"].t_coords, jnp.array([0.0, 3600.0, 7200.0, 10800.0])
-        )
-        # Mid-cell query: exactly half-way between hours 1 and 2.
-        v = dataset["u"].interp(jnp.array(5400.0), jnp.array(11.0), jnp.array(1.0))
-        assert float(v) == pytest.approx(1.5, abs=1e-6)
 
     def test_from_arrays_datetime64_matches_from_xarray(self):
         """from_arrays with datetime64 and from_xarray must yield identical t_coords."""


### PR DESCRIPTION
## Problem

A `t_origin` attribute allows to use single precision numerics to store `np.datetime64` time coordinates as seconds relative to `t_origin` instead of seconds relative to the Unix epoch which requires double precision.
This forces the user to keep track of `t_origin` (and potentially several of them if using multiple grids), and it introduces a lot of potential bugs.

## Fix

Remove `t_origin` and explicitly cast the time coordinate as `int64`. If double precision is not enabled, this will raise a warning.