### PR TITLE
Reject lon_period on face-staggered standalone Fields

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -141,7 +141,19 @@ class Field(eqx.Module):
         (e.g. in tests): the given coordinates are stored on a private
         :class:`Grid` in the slot matching ``stagger``, and the returned field
         reads them back through the usual grid-backed properties.
+
+        Raises:
+            ValueError: If ``lon_period`` is combined with a face stagger.
+                Face fields never wrap (see :meth:`pastax.Grid.period_for`),
+                so the argument would be silently ignored.
         """
+        if lon_period is not None and stagger != "center":
+            raise ValueError(
+                f"lon_period is not supported for stagger={stagger!r}: face "
+                "fields never wrap in longitude — their coordinate arrays do "
+                "not span a full period (see Grid.period_for). Build the "
+                "field without lon_period, or use stagger='center'."
+            )
         if stagger == "center":
             grid = Grid(
                 t_coords=t_coords, lat_coords=lat_coords, lon_coords=lon_coords,

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -31,6 +31,21 @@ def test_field_mask_defaults_to_none():
     assert f.mask is None
 
 
+@pytest.mark.parametrize("stagger", ["u_face", "v_face"])
+def test_standalone_rejects_lon_period_on_faces(stagger):
+    """Face fields never wrap in longitude; lon_period used to be silently
+    dropped for face staggers — it must be rejected loudly instead."""
+    with pytest.raises(ValueError, match="lon_period is not supported"):
+        Field.standalone(
+            values=jnp.zeros((2, 3, 4)),
+            t_coords=jnp.asarray([0.0, 1.0]),
+            lat_coords=jnp.linspace(0.0, 2.0, 3),
+            lon_coords=jnp.linspace(0.0, 3.0, 4),
+            lon_period=4.0,
+            stagger=stagger,
+        )
+
+
 def test_field_accepts_explicit_mask():
     mask = jnp.array([[False, True], [True, False]])
     f = Field.standalone(


### PR DESCRIPTION
## Problem

`Field.standalone` accepted `lon_period` together with `stagger="u_face"` / `"v_face"` but silently dropped it: the face branches never store it on the private `Grid`, and `Grid.period_for` returns `None` for face staggers anyway. A caller expecting periodic wrapping got silent extrapolation instead.

## Fix

Raise a `ValueError` when `lon_period` is combined with a face stagger, pointing at `Grid.period_for` for the rationale (face coordinate arrays don't span a full period, so wrapping is ill-defined).

## Tests

`test_standalone_rejects_lon_period_on_faces` (parametrized over both face staggers).