### PR TITLE
Raise an informative warning for int64 time coords without x64

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -52,6 +52,51 @@ def _coerce_time_to_seconds(t: Array) -> Array:
     return t_arr
 
 
+def _asarray_time_int64(t: Array) -> Array:
+    """Store integer-second time coordinates as a JAX ``int64`` array.
+
+    Time coordinates are kept as ``int64`` seconds so epoch-scale counts
+    (``datetime64`` input converts to seconds since the Unix epoch, ~1.7e9 s)
+    stay exact. When ``jax_enable_x64`` is disabled JAX silently truncates the
+    request to ``int32``, which represents second counts exactly only while
+    ``|t| < 2**31`` (dates before 2038-01-19); later timestamps overflow and
+    corrupt time interpolation.
+
+    JAX flags this with a generic ``int64 ... truncated to int32`` message that
+    does not mention the consequence for time. This helper suppresses that
+    message and emits a pastax-specific one instead, spelling out the overflow
+    risk and how to avoid it. Tracers are passed straight through (no host-side
+    config read while tracing).
+    """
+    import warnings
+
+    if isinstance(t, jax.Array) or jax.config.jax_enable_x64:
+        return jnp.asarray(t, dtype=jnp.int64)
+
+    with warnings.catch_warnings():
+        # Swallow JAX's generic downcast warning for this call; we re-raise a
+        # more informative one below.
+        warnings.filterwarnings(
+            "ignore",
+            message="Explicitly requested dtype int64",
+            category=UserWarning,
+        )
+        t_arr = jnp.asarray(t, dtype=jnp.int64)
+
+    warnings.warn(
+        "pastax stores time coordinates as int64 seconds, but jax_enable_x64 "
+        "is disabled so they were truncated to int32. int32 seconds are exact "
+        "only for |t| < 2**31 (dates before 2038-01-19); later timestamps "
+        "overflow and corrupt time interpolation. Enable 64-bit precision with "
+        'jax.config.update("jax_enable_x64", True) (or set JAX_ENABLE_X64=1) '
+        "before building the Dataset, or pass numeric time offsets relative to "
+        "a reference near your data instead of absolute epoch seconds.",
+        UserWarning,
+        stacklevel=3,
+    )
+    return t_arr
+
+
 def _nearest_idx(coords: Float[Array, "n"], x: Float[Array, ""], n: int) -> Array:
     """Nearest-neighbour index on an equally-spaced 1-D grid, clamped to [0, n-1]."""
     x0 = coords[0]
@@ -463,7 +508,7 @@ class Dataset(eqx.Module):
             Dataset with all fields on the given grid.
         """
         t = _coerce_time_to_seconds(t)
-        t_arr   = jnp.asarray(t,   dtype=jnp.int64)
+        t_arr   = _asarray_time_int64(t)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
         _check_periodic_lon_ascending(lon_arr, lon_period)
@@ -637,7 +682,7 @@ class Dataset(eqx.Module):
             )
 
         t = _coerce_time_to_seconds(t)
-        t_arr   = jnp.asarray(t,           dtype=jnp.int64)
+        t_arr   = _asarray_time_int64(t)
         lat_arr = jnp.asarray(center_lat,  dtype=dtype)
         lon_arr = jnp.asarray(center_lon,  dtype=dtype)
         _check_periodic_lon_ascending(lon_arr, lon_period)

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -1,5 +1,7 @@
 """Tests for forcing.py: Field and Dataset."""
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -261,6 +263,49 @@ class TestDatasetFromArrays:
             dataset["u"].t_coords,
             jnp.asarray(epoch, dtype=dataset["u"].t_coords.dtype),
         )
+
+    def test_datetime64_without_x64_warns_informatively(self):
+        """With x64 disabled, epoch-second time coords truncate to int32; the
+        loader must replace JAX's generic downcast warning with a pastax
+        message that names the 2038 overflow risk and the fix."""
+        t_dt = np.array(["2024-01-01", "2024-01-02"], dtype="datetime64[D]")
+        _, lat, lon = self._coords()
+        u = np.ones((2, 4, 4), dtype=np.float32)
+
+        was_x64 = jax.config.jax_enable_x64
+        jax.config.update("jax_enable_x64", False)
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
+            messages = [str(w.message) for w in caught]
+        finally:
+            jax.config.update("jax_enable_x64", was_x64)
+
+        assert any("jax_enable_x64" in m and "2038" in m for m in messages), messages
+        # JAX's generic message is suppressed in favour of ours.
+        assert not any(
+            "truncated to int32" in m and "pastax" not in m for m in messages
+        ), messages
+
+    def test_datetime64_with_x64_does_not_warn(self):
+        """When x64 is enabled the int64 time coords are exact — no warning."""
+        t_dt = np.array(["2024-01-01", "2024-01-02"], dtype="datetime64[D]")
+        _, lat, lon = self._coords()
+        u = np.ones((2, 4, 4), dtype=np.float32)
+
+        was_x64 = jax.config.jax_enable_x64
+        jax.config.update("jax_enable_x64", True)
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                Dataset.from_arrays({"u": u}, t=t_dt, lat=lat, lon=lon)
+            time_warnings = [
+                w for w in caught if "time coordinates" in str(w.message)
+            ]
+        finally:
+            jax.config.update("jax_enable_x64", was_x64)
+        assert time_warnings == []
 
     def test_from_arrays_datetime64_matches_from_xarray(self):
         """from_arrays with datetime64 and from_xarray must yield identical t_coords."""


### PR DESCRIPTION
## Motivation

Time coordinates are stored as `int64` seconds so epoch-scale `datetime64` counts (~1.7e9 s) stay exact. When `jax_enable_x64` is disabled, JAX truncates the `int64` request to `int32` and emits only its generic message:

> `Explicitly requested dtype int64 ... will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option ...`

That tells you *how* to enable x64 but not *why it matters here*: `int32` seconds are exact only for `|t| < 2**31` (dates before **2038-01-19**); later timestamps overflow and silently corrupt time interpolation.

## Change

Route the `int64` time conversion in both array loaders through a new `_asarray_time_int64` helper that, when x64 is off, suppresses JAX's generic warning for that call and emits a pastax-specific one naming the overflow risk and the two ways to avoid it (enable x64, or pass numeric offsets relative to a reference near the data).

- Tracers pass straight through (no host-side config read while tracing).
- x64-enabled runs are unaffected (no warning; coords are exact `int64`).

## Tests

- `test_datetime64_without_x64_warns_informatively`: with x64 off, asserts the emitted warning mentions `jax_enable_x64` and `2038`, and that JAX's generic `truncated to int32` message is *not* also surfaced.
- `test_datetime64_with_x64_does_not_warn`: with x64 on, no time warning fires.

Both toggle `jax_enable_x64` locally and restore it in a `finally`.