### PR TITLE
Support periodic longitude on C-grid U/V faces

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -141,6 +141,12 @@ class Field(eqx.Module):
         (e.g. in tests): the given coordinates are stored on a private
         :class:`Grid` in the slot matching ``stagger``, and the returned field
         reads them back through the usual grid-backed properties.
+
+        With ``lon_period`` set, the passed ``lon_coords`` are taken to span
+        exactly one period and the field wraps in longitude — for a face
+        stagger this means the coordinates must be the seam-inclusive face
+        axis (``nlon`` points; see :meth:`pastax.Grid.u_face_coords`), not the
+        ``nlon - 1`` interior faces.
         """
         if stagger == "center":
             grid = Grid(
@@ -150,13 +156,13 @@ class Field(eqx.Module):
         elif stagger == "u_face":
             grid = Grid(
                 t_coords=t_coords, lat_coords=lat_coords, lon_coords=lon_coords,
-                stagger_type="C",
+                stagger_type="C", lon_period=lon_period,
                 u_lat_coords=lat_coords, u_lon_coords=lon_coords,
             )
         elif stagger == "v_face":
             grid = Grid(
                 t_coords=t_coords, lat_coords=lat_coords, lon_coords=lon_coords,
-                stagger_type="C",
+                stagger_type="C", lon_period=lon_period,
                 v_lat_coords=lat_coords, v_lon_coords=lon_coords,
             )
         else:
@@ -590,7 +596,9 @@ class Dataset(eqx.Module):
                 which each component is registered in ``Dataset.fields``
                 (and how :meth:`velocity_interp` finds them via ``u_name`` /
                 ``v_name``) and the corresponding values. U arrays have
-                shape ``(time, nlat, nlon - 1)``; V arrays have shape
+                shape ``(time, nlat, nlon - 1)`` on a bounded grid, or
+                ``(time, nlat, nlon)`` when ``lon_period`` is set (the seam
+                east face is then represented); V arrays have shape
                 ``(time, nlat - 1, nlon)``. At least one vector must be
                 supplied; field names must be unique across all vectors
                 and tracers.
@@ -599,8 +607,9 @@ class Dataset(eqx.Module):
             u_lat: Override for U latitudes (defaults to ``center_lat``).
                 Shared by every registered U field.
             u_lon: Override for U longitudes (defaults to centre lons shifted
-                east by half a cell, length ``nlon - 1``). Shared by every
-                registered U field.
+                east by half a cell: length ``nlon - 1`` on a bounded grid, or
+                ``nlon`` when ``lon_period`` is set — the seam face included).
+                Shared by every registered U field.
             v_lat: Override for V latitudes (defaults to centre lats shifted
                 north by half a cell, length ``nlat - 1``). Shared by every
                 registered V field.
@@ -608,18 +617,19 @@ class Dataset(eqx.Module):
                 Shared by every registered V field.
             dtype: JAX dtype for all arrays (default float32).
             lon_period: If set (e.g. ``360.0``), the centre grid is treated
-                as periodic in longitude. Tracer fields receive
-                ``lon_period``; U/V faces do not (their coordinate arrays
-                no longer span a full period, so periodic wrapping would be
-                ill-defined at first order). In particular the seam U face
-                between ``lon[-1]`` and ``lon[0] + lon_period`` is not
-                represented, and U/V fields extrapolate instead of wrapping
-                across the seam — see :meth:`pastax.Grid.period_for` for the
-                implications and workarounds.
+                as periodic in longitude and every field wraps across the
+                seam. Tracer and V-face fields keep their ``nlon`` longitude
+                columns; U-face fields gain the seam east face, so U is
+                ``nlon``-wide (one face per centre cell) rather than
+                ``nlon - 1``, and its default longitudes are the centre lons
+                shifted east by half a cell (see :meth:`Grid.u_face_coords`).
+                All roles share the centre period (see
+                :meth:`pastax.Grid.period_for`).
             masks: Optional land masks keyed by the field names declared in
                 ``vectors`` and ``tracers``. Each mask is a 2-D bool array;
-                the expected shape per field is ``(nlat, nlon - 1)`` for a
-                U-face field, ``(nlat - 1, nlon)`` for a V-face field, and
+                the expected shape per field is ``(nlat, nlon - 1)`` (or
+                ``(nlat, nlon)`` when ``lon_period`` is set) for a U-face
+                field, ``(nlat - 1, nlon)`` for a V-face field, and
                 ``(nlat, nlon)`` for a tracer. When a field is absent from
                 ``masks``, a mask is inferred from NaN locations in that
                 field's values array. NaN values are always replaced with
@@ -657,12 +667,17 @@ class Dataset(eqx.Module):
         derived_u_lat, derived_u_lon = centre_grid.u_face_coords()
         derived_v_lat, derived_v_lon = centre_grid.v_face_coords()
 
+        # A periodic centre grid has one U face per centre cell (the seam face
+        # included), so U is nlon-wide; a bounded grid has nlon - 1 interior
+        # faces. V is unaffected (latitude is never periodic).
+        nlon_u = nlon if lon_period is not None else nlon - 1
+
         u_lat_arr = jnp.asarray(u_lat, dtype=dtype) if u_lat is not None else derived_u_lat
         u_lon_arr = jnp.asarray(u_lon, dtype=dtype) if u_lon is not None else derived_u_lon
         v_lat_arr = jnp.asarray(v_lat, dtype=dtype) if v_lat is not None else derived_v_lat
         v_lon_arr = jnp.asarray(v_lon, dtype=dtype) if v_lon is not None else derived_v_lon
         _check_cgrid_shape("u_lat", u_lat_arr.shape, (nlat,))
-        _check_cgrid_shape("u_lon", u_lon_arr.shape, (nlon - 1,))
+        _check_cgrid_shape("u_lon", u_lon_arr.shape, (nlon_u,))
         _check_cgrid_shape("v_lat", v_lat_arr.shape, (nlat - 1,))
         _check_cgrid_shape("v_lon", v_lon_arr.shape, (nlon,))
 
@@ -707,7 +722,7 @@ class Dataset(eqx.Module):
             v_arr = jnp.asarray(v_values, dtype=dtype)
             _check_cgrid_shape(
                 f"vectors[{group!r}]['u'] ({u_field_name!r})",
-                u_arr.shape, (nt, nlat, nlon - 1),
+                u_arr.shape, (nt, nlat, nlon_u),
             )
             _check_cgrid_shape(
                 f"vectors[{group!r}]['v'] ({v_field_name!r})",
@@ -716,7 +731,7 @@ class Dataset(eqx.Module):
 
             u_clean, u_mask = _resolve_mask(
                 u_arr, masks.get(u_field_name),
-                expected_mask_shape=(nlat, nlon - 1), field_name=u_field_name,
+                expected_mask_shape=(nlat, nlon_u), field_name=u_field_name,
             )
             v_clean, v_mask = _resolve_mask(
                 v_arr, masks.get(v_field_name),
@@ -784,8 +799,9 @@ class Dataset(eqx.Module):
                 tuple says which xarray variable holds the values and under
                 which name to register the resulting Field in
                 ``Dataset.fields``. U variables have shape
-                ``(time, nlat, nlon - 1)``; V variables have shape
-                ``(time, nlat - 1, nlon)``.
+                ``(time, nlat, nlon - 1)`` — or ``(time, nlat, nlon)`` when
+                ``lon_period`` is set (the seam east face is represented);
+                V variables have shape ``(time, nlat - 1, nlon)``.
             coordinates: Mapping with keys ``"time"``, ``"lat"``, ``"lon"``
                 → xarray coord names for the centre grid.
             tracers: Optional ``{internal_name: xarray_variable_name}`` for
@@ -876,7 +892,8 @@ def _check_cgrid_shape(name: str, got: tuple[int, ...], expected: tuple[int, ...
     if got != expected:
         raise ValueError(
             f"C-grid shape mismatch for {name}: expected {expected}, got {got}. "
-            f"NEMO convention requires U at shape (time, nlat, nlon-1) and "
+            f"NEMO convention requires U at shape (time, nlat, nlon-1) — or "
+            f"(time, nlat, nlon) on a periodic grid (lon_period set) — and "
             f"V at shape (time, nlat-1, nlon)."
         )
 

--- a/src/pastax/grid.py
+++ b/src/pastax/grid.py
@@ -70,12 +70,25 @@ class Grid(eqx.Module):
     def u_face_coords(self) -> tuple[Float[Array, "lat"], Float[Array, "lon_u"]]:
         r"""Return ``(lat_u, lon_u)`` — coordinates of U-face centres (NEMO C-grid).
 
-        For a centre grid of size ``nlon`` in longitude, U lives on the
-        ``nlon - 1`` east faces between adjacent cells:
+        For a **bounded** centre grid of size ``nlon`` in longitude, U lives on
+        the ``nlon - 1`` interior east faces between adjacent cells:
 
         .. math::
 
             \mathrm{lon}_u[i] = \tfrac{1}{2}\left(\mathrm{lon}_c[i] + \mathrm{lon}_c[i+1]\right)
+
+        When :attr:`lon_period` is set the grid is periodic, so every centre
+        cell has an east face — including the seam face between the last centre
+        and the first-plus-a-period. There are then ``nlon`` U faces, each a
+        half-cell east of its centre:
+
+        .. math::
+
+            \mathrm{lon}_u[i] = \mathrm{lon}_c[i] + \tfrac{1}{2}\,\Delta\lambda
+
+        This ``nlon``-face axis spans exactly one period, so U interpolation
+        wraps across the seam with the same first-order periodic scheme used for
+        centre fields (see :meth:`period_for`).
 
         Latitude is unchanged: :math:`\mathrm{lat}_u = \mathrm{lat}_c`.
 
@@ -84,7 +97,11 @@ class Grid(eqx.Module):
         """
         self._check_rectilinear("u_face_coords")
         lon_c = self.lon_coords
-        lon_u = 0.5 * (lon_c[:-1] + lon_c[1:])
+        if self.lon_period is None:
+            lon_u = 0.5 * (lon_c[:-1] + lon_c[1:])
+        else:
+            dlon = lon_c[1] - lon_c[0]
+            lon_u = lon_c + 0.5 * dlon
         return self.lat_coords, lon_u
 
     def v_face_coords(self) -> tuple[Float[Array, "lat_v"], Float[Array, "lon"]]:
@@ -147,19 +164,15 @@ class Grid(eqx.Module):
     ) -> float | None:
         """Return the longitude period a field at ``stagger`` should use.
 
-        Centre (tracer) fields inherit :attr:`lon_period`. U/V faces always get
-        ``None``: their coordinate arrays no longer span a full period, so
-        periodic wrapping would be ill-defined at first order.
-
-        Consequence for global (periodic) C-grids: the U face between
-        ``lon_c[-1]`` and ``lon_c[0] + lon_period`` — the seam face — is not
-        represented (there are ``nlon - 1`` U faces, not ``nlon``), and face
-        fields *extrapolate* rather than wrap across the seam. Queries near
-        the seam meridian therefore lose the C-grid's coastal guarantees; if
-        trajectories cross the seam, prefer A-grid forcing or rotate the grid
-        so the seam sits over land.
+        Every stagger role inherits :attr:`lon_period`: centre longitudes span
+        one period by construction, V-face longitudes equal the centre
+        longitudes, and periodic U faces are built seam-inclusive (``nlon``
+        faces spanning one period; see :meth:`u_face_coords`). When
+        :attr:`lon_period` is ``None`` all roles get ``None`` (bounded grid, no
+        wrapping). Latitude is never periodic, so this concerns only the
+        longitude axis.
         """
-        return self.lon_period if stagger == "center" else None
+        return self.lon_period
 
     def _check_rectilinear(self, method: str) -> None:
         if self.grid_type != "rectilinear":

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -43,6 +43,45 @@ def test_v_face_coords_shift_half_cell_in_lat():
     assert jnp.allclose(lat_v, lat[:-1] + 0.5 * dlat)
 
 
+def test_u_face_coords_periodic_includes_seam_face():
+    """On a periodic grid every centre cell has an east face (the seam face
+    included), so U is nlon-wide with faces a half-cell east of each centre."""
+    t = jnp.asarray([0.0, 3600.0])
+    lat = jnp.asarray([0.0, 1.0])
+    lon = jnp.asarray([0.0, 90.0, 180.0, 270.0])  # nlon=4, period 360
+    g = Grid(
+        t_coords=t, lat_coords=lat, lon_coords=lon,
+        stagger_type="C", lon_period=360.0,
+    )
+    lat_u, lon_u = g.u_face_coords()
+    assert jnp.allclose(lat_u, lat)
+    assert lon_u.shape == (lon.shape[0],)  # nlon, not nlon - 1
+    assert jnp.allclose(lon_u, jnp.asarray([45.0, 135.0, 225.0, 315.0]))
+    # spans exactly one period and stays equally spaced
+    assert jnp.allclose(jnp.diff(lon_u), 90.0)
+
+
+def test_period_for_returns_period_for_all_staggers_when_periodic():
+    t = jnp.asarray([0.0, 3600.0])
+    lat = jnp.asarray([0.0, 1.0])
+    lon = jnp.asarray([0.0, 90.0, 180.0, 270.0])
+    g = Grid(
+        t_coords=t, lat_coords=lat, lon_coords=lon,
+        stagger_type="C", lon_period=360.0,
+    )
+    assert g.period_for("center") == 360.0
+    assert g.period_for("u_face") == 360.0
+    assert g.period_for("v_face") == 360.0
+
+
+def test_period_for_returns_none_for_all_staggers_when_bounded():
+    t, lat, lon = _centre_grid()
+    g = Grid(t_coords=t, lat_coords=lat, lon_coords=lon, stagger_type="C")
+    assert g.period_for("center") is None
+    assert g.period_for("u_face") is None
+    assert g.period_for("v_face") is None
+
+
 def test_staggered_coords_preserve_equal_spacing():
     """The C-grid first-order interp relies on shifted coords being equally
     spaced. Verify that explicitly so a future regression (e.g. switch to a
@@ -163,6 +202,80 @@ def test_cgrid_fields_share_one_set_of_coords():
     # Time is shared by all roles.
     assert ds["u"].t_coords is ds.grid.t_coords
     assert ds["v"].t_coords is ds.grid.t_coords
+
+
+def _periodic_cgrid():
+    """Global periodic C-grid: nlon=4 centres of 90 deg; U values encode the
+    face index so wrapping is observable."""
+    t = jnp.asarray([0.0, 3600.0])
+    clat = jnp.asarray([0.0, 1.0, 2.0])
+    clon = jnp.asarray([0.0, 90.0, 180.0, 270.0])
+    nt, nlat, nlon = 2, 3, 4
+    u = jnp.broadcast_to(jnp.asarray([10.0, 11.0, 12.0, 13.0]), (nt, nlat, nlon))
+    v = jnp.zeros((nt, nlat - 1, nlon))
+    ds = Dataset.from_arrays_cgrid(
+        t, clat, clon, {"cur": {"u": ("u", u), "v": ("v", v)}}, lon_period=360.0,
+    )
+    return ds
+
+
+def test_periodic_cgrid_loader_accepts_nlon_wide_u():
+    """A periodic C-grid takes nlon-wide U (one east face per centre cell) and
+    stores the seam-inclusive face longitudes on the grid."""
+    ds = _periodic_cgrid()
+    assert ds["u"].values.shape == (2, 3, 4)          # nlon, not nlon - 1
+    assert ds["u"].lon_coords.shape == (4,)
+    assert jnp.allclose(ds["u"].lon_coords, jnp.asarray([45.0, 135.0, 225.0, 315.0]))
+    assert ds["u"].lon_period == 360.0
+    assert ds["v"].lon_period == 360.0
+
+
+def test_periodic_cgrid_rejects_bounded_u_shape():
+    """With lon_period set, an nlon-1-wide U array (the bounded shape) must be
+    rejected — the seam face is now required."""
+    t = jnp.asarray([0.0, 3600.0])
+    clat = jnp.asarray([0.0, 1.0, 2.0])
+    clon = jnp.asarray([0.0, 90.0, 180.0, 270.0])
+    u_bounded = jnp.ones((2, 3, 3))   # nlon - 1
+    v = jnp.zeros((2, 2, 4))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        Dataset.from_arrays_cgrid(
+            t, clat, clon, {"cur": {"u": ("u", u_bounded), "v": ("v", v)}},
+            lon_period=360.0,
+        )
+
+
+def test_periodic_u_face_interp_wraps_across_seam():
+    """U interpolation at lon=0 must blend the seam face (315deg -> 13) and the
+    first face (45deg -> 10) to their midpoint, rather than extrapolate."""
+    ds = _periodic_cgrid()
+    v = ds["u"].interp(jnp.asarray(0.0), jnp.asarray(0.0), jnp.asarray(1.0))
+    assert float(v) == pytest.approx(11.5, abs=1e-4)
+
+
+def test_periodic_u_face_neighborhood_wraps_across_seam():
+    ds = _periodic_cgrid()
+    nb = ds["u"].neighborhood(
+        jnp.asarray(0.0), jnp.asarray(0.0), jnp.asarray(1.0),
+        t_window=0, lat_window=0, lon_window=1,
+    )
+    # centred on face index 0 (45deg): wrapped window is [seam=13, 10, 11]
+    assert jnp.allclose(nb[0, 0], jnp.asarray([13.0, 10.0, 11.0]))
+
+
+def test_standalone_u_face_periodic_wraps():
+    """Field.standalone now stores lon_period for face staggers and wraps."""
+    lon_u = jnp.asarray([45.0, 135.0, 225.0, 315.0])  # seam-inclusive faces
+    lat = jnp.asarray([0.0, 1.0])
+    t = jnp.asarray([0.0, 1.0])
+    vals = jnp.broadcast_to(jnp.asarray([10.0, 11.0, 12.0, 13.0]), (2, 2, 4))
+    f = Field.standalone(
+        values=vals, t_coords=t, lat_coords=lat, lon_coords=lon_u,
+        lon_period=360.0, stagger="u_face",
+    )
+    assert f.lon_period == 360.0
+    v = f.interp(jnp.asarray(0.0), jnp.asarray(0.0), jnp.asarray(0.0))
+    assert float(v) == pytest.approx(11.5, abs=1e-4)
 
 
 def test_grid_backed_interp_is_jit_vmap_grad_safe():


### PR DESCRIPTION
Supersedes #31 (which merely rejected `lon_period` on faces). Instead of forbidding it, this makes periodic faces work.

## Background

`lon_period` previously wrapped only tracer (centre) fields; U/V faces always got `period_for(...) == None` and *extrapolated* across the seam meridian. That wasn't a fundamental limitation of staggered grids — it was an artifact of the **bounded** face construction: `Grid.u_face_coords` derived `nlon - 1` interior faces (`0.5*(lon_c[:-1] + lon_c[1:])`), dropping the seam east face, so the U axis no longer spanned a full period and the periodic index formula couldn't apply.

## Change

On a periodic grid every centre cell has an east face — including the seam — so U is `nlon`-wide. Derive `nlon` seam-inclusive faces (`lon_c + dlon/2`) when `lon_period` is set; that axis spans exactly one period, so the **existing** first-order periodic interpolation wraps across the seam with no change to the interpolation core. V faces already carry `nlon` longitudes, so they were shape-ready and just needed the period.

- `Grid.u_face_coords` branches on `lon_period` (`nlon` seam-inclusive vs `nlon - 1` interior faces).
- `Grid.period_for` returns the period for **every** stagger role (faces wrap in longitude too); `None` everywhere on a bounded grid.
- `from_arrays_cgrid` / `from_xarray_cgrid` expect `nlon`-wide U values, `u_lon`, and mask when `lon_period` is set; V unchanged. The bounded (`nlon - 1`) path is untouched.
- `Field.standalone` stores `lon_period` for face staggers (was silently dropped — the subject of #31).

## Compatibility

Bounded C-grids (no `lon_period`) are byte-for-byte unchanged. The behaviour change is scoped to periodic C-grids, where U now **requires** the `nlon`-wide (seam-inclusive) layout instead of `nlon - 1` — the loader raises a clear shape error otherwise.

## Tests

- Grid: periodic `u_face_coords` returns `nlon` seam-inclusive faces spanning one period; `period_for` returns the period for all roles when periodic, `None` for all when bounded.
- Loader: accepts `nlon`-wide U on a periodic grid; rejects the bounded `nlon - 1` shape.
- Wrapping: `u_face` `interp`, `velocity_interp`, and `neighborhood` all blend across the 360°→0° seam (verified to the analytic midpoint); `Field.standalone` periodic face wraps.

Full suite: 319 passed.