### PR TITLE
Fix DTypeLike import path (jax.typing, not jax)

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -14,7 +14,7 @@ from .interpolation import spatiotemporal_interp, spatiotemporal_velocity_partia
 
 if TYPE_CHECKING:
     import xarray as xr
-    from jax import DTypeLike
+    from jax.typing import DTypeLike
 
 __all__ = ["Field", "Dataset"]
 


### PR DESCRIPTION
## Problem

`DTypeLike` is exported from `jax.typing`, not the top-level `jax` namespace. The `TYPE_CHECKING` import `from jax import DTypeLike` fails to resolve — harmless at runtime (it's under `TYPE_CHECKING`), but pyright reports `"DTypeLike" is unknown import symbol` and resolves every `dtype: DTypeLike` parameter as `Unknown`.

## Fix

Import from `jax.typing`.

## Verification

Pyright (pointed at the project venv):
- **before:** `forcing.py:17: error: "DTypeLike" is unknown import symbol`
- **after:** no diagnostic.

Runtime confirms the same: `from jax import DTypeLike` raises `ImportError`; `from jax.typing import DTypeLike` succeeds. No test added — the change is confined to a `TYPE_CHECKING`-only import with no runtime surface.