### PR TITLE
Validate periodic longitude grids span exactly one period

### DIFF
--- a/src/pastax/forcing.py
+++ b/src/pastax/forcing.py
@@ -466,7 +466,7 @@ class Dataset(eqx.Module):
         t_arr   = jnp.asarray(t,   dtype=jnp.int64)
         lat_arr = jnp.asarray(lat, dtype=dtype)
         lon_arr = jnp.asarray(lon, dtype=dtype)
-        _check_periodic_lon_ascending(lon_arr, lon_period)
+        _check_periodic_lon(lon_arr, lon_period)
         nt   = int(t_arr.shape[0])
         nlat = int(lat_arr.shape[0])
         nlon = int(lon_arr.shape[0])
@@ -640,7 +640,7 @@ class Dataset(eqx.Module):
         t_arr   = jnp.asarray(t,           dtype=jnp.int64)
         lat_arr = jnp.asarray(center_lat,  dtype=dtype)
         lon_arr = jnp.asarray(center_lon,  dtype=dtype)
-        _check_periodic_lon_ascending(lon_arr, lon_period)
+        _check_periodic_lon(lon_arr, lon_period)
 
         nt   = int(t_arr.shape[0])
         nlat = int(lat_arr.shape[0])
@@ -846,15 +846,22 @@ def _is_traced(x: Array) -> bool:
     return isinstance(x, jax.core.Tracer)
 
 
-def _check_periodic_lon_ascending(
+def _check_periodic_lon(
     lon_arr: Float[Array, "lon"], lon_period: float | None
 ) -> None:
-    """Reject descending longitudes when periodic wrapping is requested.
+    """Validate longitude coordinates when periodic wrapping is requested.
 
-    The periodic index arithmetic folds queries with ``% lon_period`` above
-    ``lon_coords[0]``, which assumes an ascending axis; a descending axis
-    silently produces wrong indices and weights. (Without ``lon_period``,
-    descending coordinates work — the spacing sign cancels.)
+    Two preconditions of the periodic index arithmetic are checked:
+
+    1. **Ascending axis.** The query is folded with ``% lon_period`` above
+       ``lon_coords[0]``, which assumes an ascending axis; a descending axis
+       silently produces wrong indices and weights. (Without ``lon_period``,
+       descending coordinates work — the spacing sign cancels.)
+    2. **Spans exactly one period.** The wrap identifies the cell at
+       ``lon_coords[-1] + dlon`` with ``lon_coords[0]``, so the grid must span
+       exactly one period: ``nlon * dlon == lon_period``. A grid that does not
+       (e.g. a regional slab mislabelled periodic, or one that includes the
+       duplicate wrap endpoint) yields silently wrong wrapped indices.
 
     The check reads concrete values, so it is a no-op when ``lon_arr`` is a
     tracer (the loader was called from inside ``jit`` / ``vmap``): correctness
@@ -869,6 +876,18 @@ def _check_periodic_lon_ascending(
             "lon_period requires strictly ascending longitude coordinates; "
             "the periodic wrap arithmetic is undefined on a descending axis. "
             "Flip the longitude axis (and the field values) before loading."
+        )
+    nlon = int(lon_arr.shape[0])
+    dlon = float(lon_arr[1] - lon_arr[0])
+    implied_period = nlon * dlon
+    if abs(implied_period - lon_period) > 1e-3 * abs(lon_period):
+        raise ValueError(
+            f"lon_period={lon_period} requires the grid to span exactly one "
+            f"period (nlon * dlon == lon_period), but nlon={nlon} points with "
+            f"spacing dlon={dlon:g} span {implied_period:g}. The wrap identifies "
+            "the cell past the last centre with the first, so a periodic grid "
+            "must not include the duplicate wrap endpoint, and its extent must "
+            "equal lon_period. Check the period, or drop/append a column."
         )
 
 

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -638,6 +638,49 @@ class TestPeriodicLonAscending:
             )
 
 
+class TestPeriodicLonSpan:
+    """lon_period demands the grid span exactly one period (nlon*dlon == period)."""
+
+    def test_regional_grid_mislabelled_periodic_raises(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.array([0.0, 1.0])
+        lon = np.array([0.0, 1.0, 2.0, 3.0])  # spans 4 deg, not 360
+        u = np.ones((2, 2, 4), dtype=np.float32)
+        with pytest.raises(ValueError, match="span exactly one|span exactly"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon, lon_period=360.0)
+
+    def test_duplicate_wrap_endpoint_raises(self):
+        """Including the wrap endpoint (nlon+1 points, last == first + period)
+        overshoots one period by a cell and must be rejected."""
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.array([0.0, 1.0])
+        lon = np.array([0.0, 90.0, 180.0, 270.0, 360.0])  # 5 pts incl. wrap
+        u = np.ones((2, 2, 5), dtype=np.float32)
+        with pytest.raises(ValueError, match="span exactly one|duplicate wrap"):
+            Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon, lon_period=360.0)
+
+    def test_correct_span_accepted(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.array([0.0, 1.0])
+        lon = np.array([0.0, 90.0, 180.0, 270.0])  # 4 * 90 == 360
+        u = np.ones((2, 2, 4), dtype=np.float32)
+        ds = Dataset.from_arrays({"u": u}, t=t, lat=lat, lon=lon, lon_period=360.0)
+        assert ds["u"].lon_period == 360.0
+
+    def test_cgrid_mislabelled_periodic_raises(self):
+        t = np.linspace(0.0, 3600.0, 2)
+        lat = np.linspace(0.0, 4.0, 5)
+        lon = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])  # spans 6 deg, not 360
+        u = np.ones((2, 5, 5), dtype=np.float32)
+        v = np.ones((2, 4, 6), dtype=np.float32)
+        with pytest.raises(ValueError, match="span exactly one|span exactly"):
+            Dataset.from_arrays_cgrid(
+                t, lat, lon,
+                vectors={"current": {"u": ("uo", u), "v": ("vo", v)}},
+                lon_period=360.0,
+            )
+
+
 class TestLoadersAreTracerSafe:
     """The loaders must be callable from inside a traced (jit/vmap) region.
 


### PR DESCRIPTION
## Problem

The periodic wrap identifies the cell past the last centre (`lon[-1] + dlon`) with the first, which is only correct when the grid spans exactly one period: `nlon * dlon == lon_period`. Nothing enforced this. A grid that violates it — a regional slab mislabelled periodic, or one that mistakenly includes the duplicate wrap endpoint (`nlon + 1` points with `lon[-1] == lon[0] + period`) — produced silently wrong wrapped indices and weights.

The existing check only rejected *descending* longitudes; this closes the other precondition.

## Fix

Extend the host-side periodic-lon check (renamed `_check_periodic_lon_ascending` → `_check_periodic_lon`) to also verify `nlon * dlon == lon_period` within a small relative tolerance for float rounding. Like the ascending check, it's a no-op under tracing (the caller owns coordinate correctness inside `jit`/`vmap`).

## Tests

`TestPeriodicLonSpan`:
- regional grid (spans a few degrees) mislabelled `lon_period=360` raises;
- grid including the duplicate wrap endpoint raises;
- a correctly-spanning grid is accepted;
- same rejection on the C-grid loader.

Full suite: 315 passed.