### PR TITLE
Use safe_divide for the pole scaling in meters_to_degrees

### DIFF
--- a/src/pastax/geo.py
+++ b/src/pastax/geo.py
@@ -2,7 +2,7 @@
 
 import jax.numpy as jnp
 
-from ._safe_math import safe_sqrt
+from ._safe_math import safe_divide, safe_sqrt
 from ._types import Array, Float
 
 __all__ = [
@@ -65,6 +65,14 @@ def meters_to_degrees(
     additionally divided by :math:`\cos(\mathrm{lat})` to account for shrinking
     longitude circles toward the poles.
 
+    The division uses :func:`pastax.safe_divide`, so an *exactly* zero
+    :math:`\cos(\mathrm{lat})` yields ``0`` (with a finite gradient) rather
+    than ``inf``/``nan``. Note this is a corner-case guard only: the flat-Earth
+    longitude scaling genuinely diverges at the poles, and near (but not at)
+    :math:`\pm 90^\circ` — where :math:`\cos(\mathrm{lat})` is tiny but
+    nonzero — the zonal component is still legitimately huge. Treat results
+    within a cell of the poles as unreliable.
+
     Args:
         disp_m: Displacement(s) ``[east, north]`` in **metres**. The last axis
             must have size 2; leading axes are passed through unchanged.
@@ -77,7 +85,7 @@ def meters_to_degrees(
     rad = disp_m / EARTH_RADIUS
     deg = jnp.degrees(rad)
     lon_scale = jnp.cos(jnp.radians(lat_deg))
-    return deg.at[..., 0].divide(lon_scale)
+    return deg.at[..., 0].set(safe_divide(deg[..., 0], lon_scale))
 
 
 def degrees_to_meters(

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -78,3 +78,24 @@ class TestUnitConversions:
         one_deg = jnp.array([1.0, 1.0])
         m = degrees_to_meters(one_deg, lat)
         assert m[0] == pytest.approx(m[1] * 0.5, rel=1e-3)
+
+    def test_meters_to_degrees_finite_and_safe_at_pole(self):
+        """safe_divide keeps the forward value and gradient finite at the pole
+        (no inf/nan). The zonal component is still legitimately large there —
+        the flat-Earth longitude scaling diverges — but it must not blow up to
+        a non-finite value or poison the backward pass."""
+        disp_m = jnp.array([1000.0, 1000.0])
+        out = meters_to_degrees(disp_m, jnp.array(90.0))
+        assert jnp.all(jnp.isfinite(out))
+        g = jax.grad(lambda d: meters_to_degrees(d, jnp.array(90.0)).sum())(disp_m)
+        assert jnp.all(jnp.isfinite(g))
+
+    def test_meters_to_degrees_unchanged_at_normal_lat(self):
+        """The safe_divide swap must not change results where cos(lat) != 0."""
+        disp_m = jnp.array([1234.0, -567.0])
+        lat = jnp.array(37.0)
+        got = meters_to_degrees(disp_m, lat)
+        # Independent computation of the same naive formula.
+        deg = jnp.degrees(disp_m / EARTH_RADIUS)
+        expected = deg.at[0].divide(jnp.cos(jnp.radians(lat)))
+        assert jnp.allclose(got, expected, rtol=1e-6)


### PR DESCRIPTION
## Context

`meters_to_degrees` divides the zonal component by `cos(lat)`, which is exactly zero only in the degenerate pole case.

**Scope, stated plainly:** this is a corner-case guard, not a fix for the near-pole blowup. At `lat = 90°`, `cos(radians(90.0))` is `~6e-17` in floating point — *not* zero — so the result is already a huge-but-finite number today, and `safe_divide` does not change it (its `denominator == 0` branch never fires). `safe_divide` only affects an *exactly* zero denominator (finite gradient, returns `0`), and the flat-Earth longitude scaling genuinely diverges at the poles regardless. The docstring now says this outright.

## Change

- Route the `cos(lat)` division through `safe_divide`.
- Document that results within a cell of the poles are unreliable and that the guard only covers the exactly-zero corner.

## Tests

- `test_meters_to_degrees_finite_and_safe_at_pole`: forward value and gradient finite at `lat = 90°`.
- `test_meters_to_degrees_unchanged_at_normal_lat`: identical to the naive division where `cos(lat) != 0` (no regression from the swap).

Full suite: 331 passed.